### PR TITLE
STAR-590 Invalidate auth caches on DROP X

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -845,32 +845,75 @@ class TestAuth(Tester):
 
         assert_unauthorized(cathy, "SELECT * FROM ks.cf", "User cathy has no SELECT permission on <table ks.cf> or any of its parents")
 
-    # from 4.0 DROP/GRANT/REVOKE invalidate role and permissions caches immediately
-    # @jira_ticket STAR-590
-    @since('2.0', max_version='4')
-    def test_permissions_caching(self):
+    def test_permissions_caching_authenticated_user(self):
         """
-        * Launch a one node cluster, with a 2s permission cache
+        This test is to show that the permissions caching in AuthenticatedUser
+        works correctly and revokes the permissions from a logged in user
+        * Launch a one node cluster, with a permissions cache of 2s
         * Connect as the default superuser
-        * Create a new user, 'cathy'
-        * Create a table, ks.cf
-        * Connect as cathy in two separate sessions
-        * Grant SELECT to cathy
-        * Verify that reading from ks.cf throws Unauthorized until the cache expires
-        * Verify that after the cache expires, we can eventually read with both sessions
+        * Create USER cathy
+        * Grant SELECT permissions to cathy
+        * Verify cathy can perform expected operations
+        * Revoke SELECT permissions from cathy.
+        * Try reading as cathy, and verify that eventually the cache expires and it fails.
 
-        @jira_ticket CASSANDRA-8194
+        @jira_ticket STAR-590
         """
         self.prepare(permissions_validity=2000)
 
         cassandra = self.get_session(user='cassandra', password='cassandra')
+        cassandra.execute("CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}")
+        cassandra.execute("CREATE TABLE ks.cf (id int primary key, val int)")
+        cassandra.execute("INSERT INTO ks.cf (id, val) VALUES (0, 0)")
+
+        # grant SELECT to cathy
+        cassandra.execute("CREATE USER cathy WITH PASSWORD '12345'")
+        cassandra.execute("GRANT SELECT ON ks.cf TO cathy")
+
+        cathy = self.get_session(user='cathy', password='12345')
+
+        assert_one(cathy, "SELECT * FROM ks.cf", [0, 0])
+
+        # revoke SELECT from cathy
+        cassandra.execute("REVOKE SELECT ON ks.cf FROM cathy")
+
+        # cathy should retain permissions until the cache expires
+        # cache entries are invalidated on REVOKE in 4.0 @jira_ticket STAR-590
+        max_attempts = 1 if self.cluster.version() >= LooseVersion('4.0') else 20
+        unauthorized = None
+        cnt = 0
+        while not unauthorized and cnt < max_attempts:
+            try:
+                cathy.execute("SELECT * FROM ks.cf")
+                cnt += 1
+                time.sleep(.5)
+            except Unauthorized as e:
+                unauthorized = e
+
+    def test_permissions_caching_update_interval(self):
+        """
+        * Launch a two node cluster, with a 2s permission cache
+        * node0: Connect as the default superuser
+        *        Create a new user, 'cathy'
+        *        Create a table, ks.cf
+        * node1: Connect as cathy in two separate sessions
+        * node0: Grant SELECT to cathy
+        * node1: Verify that reading from ks.cf throws Unauthorized until the cache expires
+        *        Verify that after the cache expires, we can eventually read with both sessions
+
+        @jira_ticket CASSANDRA-8194, STAR-590
+        """
+        self.prepare(nodes=2, permissions_validity=2000)
+        node0, node1 = self.cluster.nodelist()
+
+        cassandra = self.patient_exclusive_cql_connection(node0, user='cassandra', password='cassandra')
         cassandra.execute("CREATE USER cathy WITH PASSWORD '12345'")
         cassandra.execute("CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}")
         cassandra.execute("CREATE TABLE ks.cf (id int primary key, val int)")
 
-        cathy = self.get_session(user='cathy', password='12345')
+        cathy = self.patient_exclusive_cql_connection(node1, user='cathy', password='12345')
         # another user to make sure the cache is at user level
-        cathy2 = self.get_session(user='cathy', password='12345')
+        cathy2 = self.patient_exclusive_cql_connection(node1, user='cathy', password='12345')
         cathys = [cathy, cathy2]
 
         assert_unauthorized(cathy, "SELECT * FROM ks.cf", "User cathy has no SELECT permission on <table ks.cf> or any of its parents")


### PR DESCRIPTION
DTest changes related to STAR-590, which invalidates role and permission cache entries immediately after DROP/GRANT/REVOKE statements.

* Adjusts `test_role_caching_authenticated_user` to expect immediate role cache invalidation after `REVOKE` with C* STAR-590 changes
* Adds `test_permissions_caching_authenticated_user` counterpart to above for permissions cache
* Renames `test_permissions_caching` to `test_permissions_caching_update_interval` to better indicate the test purpose; changes this test to use two nodes - one to issue `GRANT/REVOKE` and another to test the cache update interval; with this change the test will work with or without STAR-590 cache invalidation.

The `datastax/cassandra` PR is https://github.com/datastax/cassandra/pull/207

