### PR TITLE
STAR-517. Skip as it is not possible to test it reliably.

### DIFF
--- a/cqlsh_tests/test_cqlsh_copy.py
+++ b/cqlsh_tests/test_cqlsh_copy.py
@@ -2514,6 +2514,7 @@ class TestCqlshCopy(Tester):
                                    copy_to_options={'NUMPROCESSES': 5, 'MAXATTEMPTS': 20},
                                    copy_from_options={'NUMPROCESSES': 2})
 
+    @pytest.mark.skip(reason="test is not reliable and sensitive to vm power")
     def test_bulk_round_trip_with_timeouts(self):
         """
         Test bulk import with very short read and write timeout values, this should exercise the


### PR DESCRIPTION
The goal of the test is to "exercise the retry and back-off policies".
And test is trying to achieve it by:
- using arbitrary low write timeout
- and loading / exporting / importing / exporting the data
- assuming that retries and back-off will handle it.
Unfortunately it is very sensitive...

Because we need to find a perfect balance for the timeout and req/s, so that:
- timeouts are indeed hit
- and default COPY util not abort after 90s without succ write
- and default COPY will not abort after 12 unsuccessull backoff attempts

This change disables this test because:
- there is no logic in the test that would check if indeed retries and backoff are exercised, so
- it is perfectly possible that when it passes it just passes without any value
- there are special tests for MAXATTEMPTS and for backoff policy

Final note:
mechanism of retries and backoff policy in COPY command could be improved
by providing some backpressure mechanism to slowdown writes rather than
doing retry or backoff exponentital (with random!).
But this would be a new feature and COPY util is not a place we would like to invest.