### PR TITLE
STAR-386 Increase client timeout for test_simultaneous_bootstrap

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -884,8 +884,11 @@ class TestBootstrap(Tester):
         # data loads.
         logger.error(node1.nodetool('status').stdout)
         for _ in range(5):
-            logger.error("Executing SELECT to node2")
-            assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE)
+            logger.error("Executing SELECT to node2 {}".format(_))
+            try:
+                assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE, timeout=30)
+            finally:
+                logger.error("SELECT finished")
 
     def test_cleanup(self):
         """

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -882,13 +882,8 @@ class TestBootstrap(Tester):
         # Repeat the select count(*) query, to help catch
         # bugs like 9484, where count(*) fails at higher
         # data loads.
-        logger.error(node1.nodetool('status').stdout)
         for _ in range(5):
-            logger.error("Executing SELECT to node2 {}".format(_))
-            try:
-                assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE, timeout=30)
-            finally:
-                logger.error("SELECT finished")
+            assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE, timeout=30)
 
     def test_cleanup(self):
         """

--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -883,6 +883,7 @@ class TestBootstrap(Tester):
         # bugs like 9484, where count(*) fails at higher
         # data loads.
         for _ in range(5):
+            # Improve reliability for slower/loaded test systems by using larger client timeout
             assert_one(session, "SELECT count(*) from keyspace1.standard1", [500000], cl=ConsistencyLevel.ONE, timeout=30)
 
     def test_cleanup(self):

--- a/tools/assertions.py
+++ b/tools/assertions.py
@@ -114,7 +114,7 @@ def assert_unauthorized(session, query, message):
     assert_exception(session, query, matching=message, expected=Unauthorized)
 
 
-def assert_one(session, query, expected, cl=None):
+def assert_one(session, query, expected, cl=None, timeout=None):
     """
     Assert query returns one row.
     @param session Session to use
@@ -127,7 +127,7 @@ def assert_one(session, query, expected, cl=None):
     assert_one(session, query, [0, 0])
     """
     simple_query = SimpleStatement(query, consistency_level=cl)
-    res = session.execute(simple_query)
+    res = session.execute(simple_query) if timeout is None else session.execute(simple_query, timeout=timeout)
     list_res = _rows_to_list(res)
     assert list_res == [expected], "Expected {} from {}, but got {}".format([expected], query, list_res)
 


### PR DESCRIPTION
Improve reliability for slow/loaded test systems by using larger client timeout executing query.