### PR TITLE
STAR-775 fix skipping marked tests

### DIFF
--- a/meta_tests/conftest_test.py
+++ b/meta_tests/conftest_test.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
+import pytest
+
 from conftest import is_skippable
-from mock import Mock
+from mock import Mock, patch
 
 class DTestConfigMock():
     def __init__(self):
@@ -13,10 +15,17 @@ class DTestConfigMock():
         self.use_vnodes = False
         self.use_off_heap_memtables = False
 
+    def set(self, config):
+        if config != "":
+            setattr(self, config, True)
+
 def _mock_responses(responses, default_response=None):
     return lambda arg: responses[arg] if arg in responses else default_response
 
-class ConfTestTest(TestCase):
+def _mock_responses_any(responses, default_response=None):
+    return lambda i, m: responses[m] if m in responses else default_response
+
+class TestConfTest(object):
     regular_test = Mock(name="regular_test_mock")
     upgrade_test = Mock(name="upgrade_test_mock")
     resource_intensive_test = Mock(name="resource_intensive_test_mock")
@@ -24,6 +33,18 @@ class ConfTestTest(TestCase):
     no_vnodes_test = Mock(name="no_vnodes_test_mock")
     no_offheap_memtables_test = Mock(name="no_offheap_memtables_test_mock")
     depends_driver_test = Mock(name="depends_driver_test_mock")
+
+    no_patch = Mock(name="any_class_has_mark_none", side_effect= _mock_responses_any({}))
+    upgrade_test_patch = Mock(name="any_class_has_mark_upgrade_test",
+                              side_effect= _mock_responses_any({"upgrade_test": True}))
+    resource_intensive_patch = Mock(name="any_class_has_mark_resource_intensive",
+                                    side_effect= _mock_responses_any({"resource_intensive": True}))
+    vnodes_patch = Mock(name="any_class_has_mark_vnodes", side_effect= _mock_responses_any({"vnodes": True}))
+    no_vnodes_patch = Mock(name="any_class_has_mark_no_vnodes", side_effect= _mock_responses_any({"no_vnodes": True}))
+    no_offheap_memtables_patch = Mock(name="any_class_has_mark_no_offheap_memtables",
+                                      side_effect= _mock_responses_any({"no_offheap_memtables": True}))
+    depends_driver_patch = Mock(name="any_class_has_mark_depends_dirver",
+                                side_effect= _mock_responses_any({"depends_driver": True}))
 
     def setup_method(self, method):
         self.regular_test.get_closest_marker.side_effect = _mock_responses({})
@@ -34,90 +55,105 @@ class ConfTestTest(TestCase):
         self.no_offheap_memtables_test.get_closest_marker.side_effect = _mock_responses({"no_offheap_memtables": True})
         self.depends_driver_test.get_closest_marker.side_effect = _mock_responses({"depends_driver": True})
 
-    def test_regular_test(self):
+    @pytest.mark.parametrize("item", [upgrade_test, resource_intensive_test, vnodes_test, depends_driver_test])
+    @pytest.mark.parametrize("a_class_marked", [no_patch, upgrade_test_patch, resource_intensive_patch, vnodes_patch,
+                                           no_vnodes_patch, no_offheap_memtables_patch, depends_driver_patch])
+    def test_skip_if_no_config(self, item, a_class_marked):
         dtest_config = DTestConfigMock()
-        # No configuration arguments provided
-        assert not is_skippable(self.regular_test, dtest_config, True)
-        assert not is_skippable(self.regular_test, dtest_config, False)
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert is_skippable(item, dtest_config, False)
 
-        # Configuration arguments do not affect tests without mark
+    @pytest.mark.parametrize("config", ["execute_upgrade_tests_only", "only_resource_intensive_tests"])
+    @pytest.mark.parametrize("a_class_marked", [no_patch, resource_intensive_patch, vnodes_patch, no_vnodes_patch,
+                                           no_offheap_memtables_patch, depends_driver_patch])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_skip_if_no_direct_marks(self, config, a_class_marked, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert is_skippable(self.regular_test, dtest_config, sufficient_resources)
+
+    @pytest.mark.parametrize("item", [regular_test, resource_intensive_test, no_vnodes_test, no_offheap_memtables_test])
+    @pytest.mark.parametrize("a_class_marked", [no_patch, resource_intensive_patch, vnodes_patch, no_vnodes_patch,
+                                           no_offheap_memtables_patch, depends_driver_patch])
+    def test_include_if_no_config(self, item, a_class_marked):
+        dtest_config = DTestConfigMock()
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert not is_skippable(self.regular_test, dtest_config, True)
+
+    @pytest.mark.parametrize("a_class_marked", [no_patch, resource_intensive_patch, vnodes_patch, no_vnodes_patch,
+                                           no_offheap_memtables_patch, depends_driver_patch])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_if_no_direct_marks(self, a_class_marked, sufficient_resources):
+        dtest_config = DTestConfigMock()
         dtest_config.execute_upgrade_tests = True
         dtest_config.force_execution_of_resource_intensive_tests = True
         dtest_config.skip_resource_intensive_tests = True
         dtest_config.use_vnodes = True
         dtest_config.use_off_heap_memtables = True
-        assert not is_skippable(self.regular_test, dtest_config, False)
-        dtest_config.execute_upgrade_tests = False
-        dtest_config.force_execution_of_resource_intensive_tests = False
-        dtest_config.skip_resource_intensive_tests = False
-        dtest_config.use_vnodes = False
-        dtest_config.use_off_heap_memtables = False
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert not is_skippable(self.regular_test, dtest_config, sufficient_resources)
 
-        # Configurations making tests without mark to be skipped
-        dtest_config.only_resource_intensive_tests = True
-        assert is_skippable(self.regular_test, dtest_config, True)
-        assert is_skippable(self.regular_test, dtest_config, False)
-        dtest_config.only_resource_intensive_tests = False
-
-        dtest_config.execute_upgrade_tests_only = True
-        assert is_skippable(self.regular_test, dtest_config, True)
-        dtest_config.execute_upgrade_tests_only = False
-
-    def test_upgrade_test(self):
+    @pytest.mark.parametrize("item,a_class_marked", [(regular_test, upgrade_test_patch),
+                                                (upgrade_test, no_patch),
+                                                (upgrade_test, upgrade_test_patch)])
+    def test_skip_upgrade_test(self, item, a_class_marked):
         dtest_config = DTestConfigMock()
-        assert is_skippable(self.upgrade_test, dtest_config, True)
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert is_skippable(item, dtest_config, True)
 
-        dtest_config.execute_upgrade_tests = True
-        assert not is_skippable(self.upgrade_test, dtest_config, True)
-        dtest_config.execute_upgrade_tests = False
+    @pytest.mark.parametrize("item, a_class_marked", [(regular_test, upgrade_test_patch),
+                                                 (upgrade_test, no_patch),
+                                                 (upgrade_test, upgrade_test_patch)])
+    @pytest.mark.parametrize("config", ["execute_upgrade_tests", "execute_upgrade_tests_only"])
+    def test_include_upgrade_test(self, item, a_class_marked, config):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert not is_skippable(item, dtest_config, False)
 
-        dtest_config.execute_upgrade_tests_only = True
-        assert not is_skippable(self.upgrade_test, dtest_config, True)
-        dtest_config.execute_upgrade_tests_only = False
+    @pytest.mark.parametrize("config, sufficient_resources", [("", False),
+                                                              ("skip_resource_intensive_tests", True),
+                                                              ("skip_resource_intensive_tests", False)])
+    def test_skip_resource_intensive(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert is_skippable(self.resource_intensive_test, dtest_config, sufficient_resources)
 
-    def test_resource_intensive_test(self):
+    @pytest.mark.parametrize("config", ["force_execution_of_resource_intensive_tests", "only_resource_intensive_tests"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_resource_intensive_if_any_resources(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert not is_skippable(self.resource_intensive_test, dtest_config, sufficient_resources)
+
+    def test_include_resource_intensive_if_sufficient_resources_no_config(self):
         dtest_config = DTestConfigMock()
         assert not is_skippable(self.resource_intensive_test, dtest_config, True)
-        assert is_skippable(self.resource_intensive_test, dtest_config, False)
 
-        dtest_config.force_execution_of_resource_intensive_tests = True
-        assert not is_skippable(self.resource_intensive_test, dtest_config, True)
-        assert not is_skippable(self.resource_intensive_test, dtest_config, False)
-        dtest_config.force_execution_of_resource_intensive_tests = False
-
-        dtest_config.only_resource_intensive_tests = True
-        assert not is_skippable(self.resource_intensive_test, dtest_config, True)
-        assert not is_skippable(self.resource_intensive_test, dtest_config, False)
-        dtest_config.only_resource_intensive_tests = False
-
-        dtest_config.skip_resource_intensive_tests = True
-        assert is_skippable(self.resource_intensive_test, dtest_config, True)
-        dtest_config.skip_resource_intensive_tests = False
-
-    def test_vnodes_test(self):
+    @pytest.mark.parametrize("a_class_marked", [no_patch, vnodes_patch, no_vnodes_patch])
+    def test_include_vnodes(self, a_class_marked):
         dtest_config = DTestConfigMock()
-        assert is_skippable(self.vnodes_test, dtest_config, True)
-
         dtest_config.use_vnodes = True
-        assert not is_skippable(self.vnodes_test, dtest_config, True)
-        dtest_config.use_vnodes = False
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert not is_skippable(self.vnodes_test, dtest_config, False)
 
-    def test_no_vnodes_test(self):
+    @pytest.mark.parametrize("a_class_marked", [no_patch, vnodes_patch, no_vnodes_patch])
+    def test_include_no_vnodes(self, a_class_marked):
         dtest_config = DTestConfigMock()
-        assert not is_skippable(self.no_vnodes_test, dtest_config, True)
+        with patch('conftest.any_class_in_module_has_mark', a_class_marked):
+            assert not is_skippable(self.no_vnodes_test, dtest_config, False)
 
-        dtest_config.use_vnodes = True
-        assert is_skippable(self.no_vnodes_test, dtest_config, True)
-        dtest_config.use_vnodes = False
-
-    def test_no_offheap_memtables_test(self):
+    def test_skip_no_offheap_memtables(self):
         dtest_config = DTestConfigMock()
+        dtest_config.use_off_heap_memtables
         assert not is_skippable(self.no_offheap_memtables_test, dtest_config, True)
 
-        dtest_config.use_off_heap_memtables = True
-        assert is_skippable(self.no_offheap_memtables_test, dtest_config, True)
-        dtest_config.use_off_heap_memtables = False
-
-    def test_depends_driver_test(self):
+    @pytest.mark.parametrize("config", ["", "execute_upgrade_tests", "execute_upgrade_tests_only",
+                                        "force_execution_of_resource_intensive_tests", "only_resource_intensive_tests",
+                                        "skip_resource_intensive_tests","use_vnodes", "use_off_heap_memtables"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_skip_depends_driver_always(self, config, sufficient_resources):
         dtest_config = DTestConfigMock()
-        assert is_skippable(self.depends_driver_test, dtest_config, True)
+        dtest_config.set(config)
+        assert is_skippable(self.depends_driver_test, dtest_config, sufficient_resources)

--- a/meta_tests/conftest_test.py
+++ b/meta_tests/conftest_test.py
@@ -3,28 +3,18 @@ from unittest import TestCase
 from conftest import is_skippable
 from mock import Mock
 
+class DTestConfigMock():
+    def __init__(self):
+        self.execute_upgrade_tests = False
+        self.execute_upgrade_tests_only = False
+        self.force_execution_of_resource_intensive_tests = False
+        self.only_resource_intensive_tests = False
+        self.skip_resource_intensive_tests = False
+        self.use_vnodes = False
+        self.use_off_heap_memtables = False
 
 def _mock_responses(responses, default_response=None):
     return lambda arg: responses[arg] if arg in responses else default_response
-
-
-def _is_skippable(item,
-                  include_upgrade_tests=True,
-                  include_non_upgrade_tests=True,
-                  include_resource_intensive_tests=True,
-                  include_non_resource_intensive_tests=True,
-                  include_vnodes_tests=True,
-                  include_no_vnodes_tests=True,
-                  include_no_offheap_memtables_tests=True):
-    return is_skippable(item,
-                        include_upgrade_tests,
-                        include_non_upgrade_tests,
-                        include_resource_intensive_tests,
-                        include_non_resource_intensive_tests,
-                        include_vnodes_tests,
-                        include_no_vnodes_tests,
-                        include_no_offheap_memtables_tests)
-
 
 class ConfTestTest(TestCase):
     regular_test = Mock(name="regular_test_mock")
@@ -45,29 +35,89 @@ class ConfTestTest(TestCase):
         self.depends_driver_test.get_closest_marker.side_effect = _mock_responses({"depends_driver": True})
 
     def test_regular_test(self):
-        assert not _is_skippable(item=self.regular_test)
-        assert _is_skippable(item=self.regular_test, include_non_upgrade_tests=False)
-        assert _is_skippable(item=self.regular_test, include_non_resource_intensive_tests=False)
+        dtest_config = DTestConfigMock()
+        # No configuration arguments provided
+        assert not is_skippable(self.regular_test, dtest_config, True)
+        assert not is_skippable(self.regular_test, dtest_config, False)
+
+        # Configuration arguments do not affect tests without mark
+        dtest_config.execute_upgrade_tests = True
+        dtest_config.force_execution_of_resource_intensive_tests = True
+        dtest_config.skip_resource_intensive_tests = True
+        dtest_config.use_vnodes = True
+        dtest_config.use_off_heap_memtables = True
+        assert not is_skippable(self.regular_test, dtest_config, False)
+        dtest_config.execute_upgrade_tests = False
+        dtest_config.force_execution_of_resource_intensive_tests = False
+        dtest_config.skip_resource_intensive_tests = False
+        dtest_config.use_vnodes = False
+        dtest_config.use_off_heap_memtables = False
+
+        # Configurations making tests without mark to be skipped
+        dtest_config.only_resource_intensive_tests = True
+        assert is_skippable(self.regular_test, dtest_config, True)
+        assert is_skippable(self.regular_test, dtest_config, False)
+        dtest_config.only_resource_intensive_tests = False
+
+        dtest_config.execute_upgrade_tests_only = True
+        assert is_skippable(self.regular_test, dtest_config, True)
+        dtest_config.execute_upgrade_tests_only = False
 
     def test_upgrade_test(self):
-        assert not _is_skippable(item=self.upgrade_test)
-        assert _is_skippable(item=self.upgrade_test, include_upgrade_tests=False)
+        dtest_config = DTestConfigMock()
+        assert is_skippable(self.upgrade_test, dtest_config, True)
+
+        dtest_config.execute_upgrade_tests = True
+        assert not is_skippable(self.upgrade_test, dtest_config, True)
+        dtest_config.execute_upgrade_tests = False
+
+        dtest_config.execute_upgrade_tests_only = True
+        assert not is_skippable(self.upgrade_test, dtest_config, True)
+        dtest_config.execute_upgrade_tests_only = False
 
     def test_resource_intensive_test(self):
-        assert not _is_skippable(item=self.resource_intensive_test)
-        assert _is_skippable(item=self.resource_intensive_test, include_resource_intensive_tests=False)
+        dtest_config = DTestConfigMock()
+        assert not is_skippable(self.resource_intensive_test, dtest_config, True)
+        assert is_skippable(self.resource_intensive_test, dtest_config, False)
+
+        dtest_config.force_execution_of_resource_intensive_tests = True
+        assert not is_skippable(self.resource_intensive_test, dtest_config, True)
+        assert not is_skippable(self.resource_intensive_test, dtest_config, False)
+        dtest_config.force_execution_of_resource_intensive_tests = False
+
+        dtest_config.only_resource_intensive_tests = True
+        assert not is_skippable(self.resource_intensive_test, dtest_config, True)
+        assert not is_skippable(self.resource_intensive_test, dtest_config, False)
+        dtest_config.only_resource_intensive_tests = False
+
+        dtest_config.skip_resource_intensive_tests = True
+        assert is_skippable(self.resource_intensive_test, dtest_config, True)
+        dtest_config.skip_resource_intensive_tests = False
 
     def test_vnodes_test(self):
-        assert not _is_skippable(item=self.vnodes_test)
-        assert _is_skippable(item=self.vnodes_test, include_vnodes_tests=False)
+        dtest_config = DTestConfigMock()
+        assert is_skippable(self.vnodes_test, dtest_config, True)
+
+        dtest_config.use_vnodes = True
+        assert not is_skippable(self.vnodes_test, dtest_config, True)
+        dtest_config.use_vnodes = False
 
     def test_no_vnodes_test(self):
-        assert not _is_skippable(item=self.no_vnodes_test)
-        assert _is_skippable(item=self.no_vnodes_test, include_no_vnodes_tests=False)
+        dtest_config = DTestConfigMock()
+        assert not is_skippable(self.no_vnodes_test, dtest_config, True)
+
+        dtest_config.use_vnodes = True
+        assert is_skippable(self.no_vnodes_test, dtest_config, True)
+        dtest_config.use_vnodes = False
 
     def test_no_offheap_memtables_test(self):
-        assert not _is_skippable(item=self.no_offheap_memtables_test)
-        assert _is_skippable(item=self.no_offheap_memtables_test, include_no_offheap_memtables_tests=False)
+        dtest_config = DTestConfigMock()
+        assert not is_skippable(self.no_offheap_memtables_test, dtest_config, True)
+
+        dtest_config.use_off_heap_memtables = True
+        assert is_skippable(self.no_offheap_memtables_test, dtest_config, True)
+        dtest_config.use_off_heap_memtables = False
 
     def test_depends_driver_test(self):
-        assert _is_skippable(item=self.depends_driver_test)
+        dtest_config = DTestConfigMock()
+        assert is_skippable(self.depends_driver_test, dtest_config, True)


### PR DESCRIPTION
This commit fixes few unexpected behaviours, which were:
1. If any test class is marked with `resource_intensive`, then all tests
   in the file were treated as resource intensive.
2. If one test class is marked with `vnodes` and another test class is
   marked with `no_vnodes` in the same file, then all tests were
   skipped in the file.
3. If a test run is executed with the argument
   `--only-resource-intensive-tests` and there is no sufficient
   resources for resource intensive tests, then no tests were executed.
   Thus it was necessary to provide `-force-resource-intensive-tests`
   in addition.

As the result of this commit:
- Marks on other classes in the file do not affect a test, which is
  not marked and neither its class. The only exception is
  `upgrade_test`, where marking any class in a file will mark all
  tests in the file as `upgrade_test`. This fixes STAR-775, which is
  about resource intensive tests, and tests with `vnodes` and
  `no_vnodes`.
- `--only-resource-intensive-tests` does not require sufficient
  resources any more, so specifying it will execute only resource
  intensive tests independently on available resources.

The unit tests of `is_shippable` from `conftest.py` are changed to test
calculating skipping/includeing conditions from prvoided mocked
configurations instead of shipping if conditions are satisfied or not.
More test cases were added.

Few things might be good to fix:
- It is still difficult to follow the logic when tests are included or
  skipped.
- With this patch the conditions to include or skip a test are
  calculated for every test, but can be done once for all, since the
  conditions are dependent on configurations. This change was needed
  to improve unit tests. It might be not worth to fix it, since it
  will increase the complexity of the code, while perfomance overhead
  is not expected to be noticable in comparison with test execution.
- Having marks on other test classes in the same file is not mocked
  and not tested.
- Unit tests look agly and might be not easy to follow.