### PR TITLE
STAR-775 fix skipping marked tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -545,53 +545,46 @@ def cassandra_dir_and_version(config):
     return cassandra_dir, cassandra_version
 
 
-def has_mark(item, mark):
+def _is_skippable(item, mark, skip_marked, skip_non_marked):
     if item.get_closest_marker(mark) is not None:
-        return True
-    else:
-        for item_module in inspect.getmembers(item.module, inspect.isclass):
-            if hasattr(item_module[1], "pytestmark"):
-                mark_names = [m.name for m in item_module[1].pytestmark]
-                if mark in mark_names:
-                    return True
-
-        return False
-
-
-def _is_skippable(item, mark, include_marked, include_other):
-    if has_mark(item, mark):
-        if include_marked:
-            return False
-        else:
-            logger.info("SKIP: Skipping %s because it is marked with %s" % (item, mark))
+        if skip_marked:
+            logger.info(
+                "SKIP: Skipping %s because it is marked with %s" % (item, mark))
             return True
-    else:
-        if include_other:
-            return False
         else:
-            logger.info("SKIP: Skipping %s because it is not marked with %s" % (item, mark))
+            return False
+    else:
+        if skip_non_marked:
+            logger.info(
+                "SKIP: Skipping %s because it is not marked with %s" % (item, mark))
             return True
+        else:
+            return False
 
 
-def is_skippable(item,
-                 include_upgrade_tests,
-                 include_non_upgrade_tests,
-                 include_resource_intensive_tests,
-                 include_non_resource_intensive_tests,
-                 include_vnodes_tests,
-                 include_no_vnodes_tests,
-                 include_no_offheap_memtables_tests):
+class SkipConditions:
+    def __init__(self, dtest_config, sufficient_resources):
+        self.skip_upgrade_tests = not dtest_config.execute_upgrade_tests and not dtest_config.execute_upgrade_tests_only
+        self.skip_non_upgrade_tests = dtest_config.execute_upgrade_tests_only
+        self.skip_resource_intensive_tests = (
+            not dtest_config.force_execution_of_resource_intensive_tests and
+            not dtest_config.only_resource_intensive_tests and
+            not sufficient_resources) or dtest_config.skip_resource_intensive_tests
+        self.skip_non_resource_intensive_tests = dtest_config.only_resource_intensive_tests
+        self.skip_vnodes_tests = not dtest_config.use_vnodes
+        self.skip_no_vnodes_tests = dtest_config.use_vnodes
+        self.skip_no_offheap_memtables_tests = dtest_config.use_off_heap_memtables
 
-    skippable = False
 
-    skippable = skippable or _is_skippable(item, "upgrade_test", include_upgrade_tests, include_non_upgrade_tests)
-    skippable = skippable or _is_skippable(item, "resource_intensive", include_resource_intensive_tests, include_non_resource_intensive_tests)
-    skippable = skippable or _is_skippable(item, "vnodes", include_vnodes_tests, True)
-    skippable = skippable or _is_skippable(item, "no_vnodes", include_no_vnodes_tests, True)
-    skippable = skippable or _is_skippable(item, "no_offheap_memtables", include_no_offheap_memtables_tests, True)
-    skippable = skippable or _is_skippable(item, "depends_driver", False, True)
-
-    return skippable
+def is_skippable(item, skip_cond):
+    return (_is_skippable(item, "upgrade_test",
+                          skip_cond.skip_upgrade_tests, skip_cond.skip_non_upgrade_tests)
+            or _is_skippable(item, "resource_intensive",
+                             skip_cond.skip_resource_intensive_tests, skip_cond.skip_non_resource_intensive_tests)
+            or _is_skippable(item, "vnodes", skip_cond.skip_vnodes_tests, skip_non_marked=False)
+            or _is_skippable(item, "no_vnodes", skip_cond.skip_no_vnodes_tests, skip_non_marked=False)
+            or _is_skippable(item, "no_offheap_memtables", skip_cond.skip_no_offheap_memtables_tests, skip_non_marked=False)
+            or _is_skippable(item, "depends_driver", skip_marked=True, skip_non_marked=False))
 
 
 def pytest_collection_modifyitems(items, config):
@@ -605,28 +598,17 @@ def pytest_collection_modifyitems(items, config):
     selected_items = []
     deselected_items = []
 
-    can_run_resource_intensive_tests = dtest_config.force_execution_of_resource_intensive_tests or sufficient_system_resources_for_resource_intensive_tests()
-    if not can_run_resource_intensive_tests:
-        logger.info("Resource intensive tests will be skipped because there is not enough system resource "
-                    "and --force-resource-intensive-tests was not specified")
+    sufficient_resources = sufficient_system_resources_for_resource_intensive_tests()
+    skip_conditions = SkipConditions(dtest_config, sufficient_resources)
 
-    include_upgrade_tests = dtest_config.execute_upgrade_tests or dtest_config.execute_upgrade_tests_only
-    include_non_upgrade_tests = not dtest_config.execute_upgrade_tests_only
-    include_resource_intensive_tests = can_run_resource_intensive_tests and not dtest_config.skip_resource_intensive_tests
-    include_non_resource_intensive_tests = not dtest_config.only_resource_intensive_tests
-    include_vnodes_tests = dtest_config.use_vnodes
-    include_no_vnodes_tests = not dtest_config.use_vnodes
-    include_no_offheap_memtables_tests = not dtest_config.use_off_heap_memtables
+    if skip_conditions.skip_resource_intensive_tests:
+        logger.info("Resource intensive tests will be skipped because "
+                    "it was requested to skip or there is not enough system resource "
+                    "and --force-resource-intensive-tests or --only-resource-intensive-tests "
+                    "were not specified")
 
     for item in items:
-        deselect_test = is_skippable(item,
-                                     include_upgrade_tests,
-                                     include_non_upgrade_tests,
-                                     include_resource_intensive_tests,
-                                     include_non_resource_intensive_tests,
-                                     include_vnodes_tests,
-                                     include_no_vnodes_tests,
-                                     include_no_offheap_memtables_tests)
+        deselect_test = is_skippable(item, skip_conditions)
 
         if deselect_test:
             deselected_items.append(item)

--- a/meta_tests/conftest_test.py
+++ b/meta_tests/conftest_test.py
@@ -1,32 +1,29 @@
-from unittest import TestCase
+import pytest
 
-from conftest import is_skippable
+from conftest import SkipConditions, dtest_config, is_skippable
 from mock import Mock
+
+
+class DTestConfigMock():
+    def __init__(self):
+        self.execute_upgrade_tests = False
+        self.execute_upgrade_tests_only = False
+        self.force_execution_of_resource_intensive_tests = False
+        self.only_resource_intensive_tests = False
+        self.skip_resource_intensive_tests = False
+        self.use_vnodes = False
+        self.use_off_heap_memtables = False
+
+    def set(self, config):
+        if config != "":
+            setattr(self, config, True)
 
 
 def _mock_responses(responses, default_response=None):
     return lambda arg: responses[arg] if arg in responses else default_response
 
 
-def _is_skippable(item,
-                  include_upgrade_tests=True,
-                  include_non_upgrade_tests=True,
-                  include_resource_intensive_tests=True,
-                  include_non_resource_intensive_tests=True,
-                  include_vnodes_tests=True,
-                  include_no_vnodes_tests=True,
-                  include_no_offheap_memtables_tests=True):
-    return is_skippable(item,
-                        include_upgrade_tests,
-                        include_non_upgrade_tests,
-                        include_resource_intensive_tests,
-                        include_non_resource_intensive_tests,
-                        include_vnodes_tests,
-                        include_no_vnodes_tests,
-                        include_no_offheap_memtables_tests)
-
-
-class ConfTestTest(TestCase):
+class TestConfTest(object):
     regular_test = Mock(name="regular_test_mock")
     upgrade_test = Mock(name="upgrade_test_mock")
     resource_intensive_test = Mock(name="resource_intensive_test_mock")
@@ -37,37 +34,112 @@ class ConfTestTest(TestCase):
 
     def setup_method(self, method):
         self.regular_test.get_closest_marker.side_effect = _mock_responses({})
-        self.upgrade_test.get_closest_marker.side_effect = _mock_responses({"upgrade_test": True})
-        self.resource_intensive_test.get_closest_marker.side_effect = _mock_responses({"resource_intensive": True})
-        self.vnodes_test.get_closest_marker.side_effect = _mock_responses({"vnodes": True})
-        self.no_vnodes_test.get_closest_marker.side_effect = _mock_responses({"no_vnodes": True})
-        self.no_offheap_memtables_test.get_closest_marker.side_effect = _mock_responses({"no_offheap_memtables": True})
-        self.depends_driver_test.get_closest_marker.side_effect = _mock_responses({"depends_driver": True})
+        self.upgrade_test.get_closest_marker.side_effect = _mock_responses(
+            {"upgrade_test": True})
+        self.resource_intensive_test.get_closest_marker.side_effect = _mock_responses(
+            {"resource_intensive": True})
+        self.vnodes_test.get_closest_marker.side_effect = _mock_responses(
+            {"vnodes": True})
+        self.no_vnodes_test.get_closest_marker.side_effect = _mock_responses(
+            {"no_vnodes": True})
+        self.no_offheap_memtables_test.get_closest_marker.side_effect = _mock_responses(
+            {"no_offheap_memtables": True})
+        self.depends_driver_test.get_closest_marker.side_effect = _mock_responses(
+            {"depends_driver": True})
 
-    def test_regular_test(self):
-        assert not _is_skippable(item=self.regular_test)
-        assert _is_skippable(item=self.regular_test, include_non_upgrade_tests=False)
-        assert _is_skippable(item=self.regular_test, include_non_resource_intensive_tests=False)
+    @pytest.mark.parametrize("item", [upgrade_test, resource_intensive_test, vnodes_test,
+                                      depends_driver_test])
+    def test_skip_if_no_config(self, item):
+        dtest_config = DTestConfigMock()
+        assert is_skippable(item, SkipConditions(dtest_config, False))
 
-    def test_upgrade_test(self):
-        assert not _is_skippable(item=self.upgrade_test)
-        assert _is_skippable(item=self.upgrade_test, include_upgrade_tests=False)
+    @pytest.mark.parametrize("item", [regular_test, resource_intensive_test, no_vnodes_test,
+                                      no_offheap_memtables_test])
+    def test_include_if_no_config(self, item):
+        dtest_config = DTestConfigMock()
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_resource_intensive_test(self):
-        assert not _is_skippable(item=self.resource_intensive_test)
-        assert _is_skippable(item=self.resource_intensive_test, include_resource_intensive_tests=False)
+    @pytest.mark.parametrize("item,config",
+                             [(upgrade_test, "execute_upgrade_tests_only"),
+                              (resource_intensive_test, "only_resource_intensive_tests")])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_if_config_only(self, item, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert not is_skippable(item, SkipConditions(
+            dtest_config, sufficient_resources))
 
-    def test_vnodes_test(self):
-        assert not _is_skippable(item=self.vnodes_test)
-        assert _is_skippable(item=self.vnodes_test, include_vnodes_tests=False)
+    @pytest.mark.parametrize("item",
+                             [regular_test, upgrade_test, resource_intensive_test, vnodes_test,
+                              no_vnodes_test, no_offheap_memtables_test])
+    @pytest.mark.parametrize("only_item,config",
+                             [(upgrade_test, "execute_upgrade_tests_only"),
+                              (resource_intensive_test, "only_resource_intensive_tests")])
+    def test_config_only(self, item, only_item, config):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        if item != only_item:
+            assert is_skippable(item, SkipConditions(dtest_config, True))
+        else:
+            assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_no_vnodes_test(self):
-        assert not _is_skippable(item=self.no_vnodes_test)
-        assert _is_skippable(item=self.no_vnodes_test, include_no_vnodes_tests=False)
+    @pytest.mark.parametrize("item",
+                             [regular_test, upgrade_test, resource_intensive_test,
+                              no_vnodes_test, no_offheap_memtables_test])
+    def test_include_if_execute_upgrade(self, item):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("execute_upgrade_tests")
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
 
-    def test_no_offheap_memtables_test(self):
-        assert not _is_skippable(item=self.no_offheap_memtables_test)
-        assert _is_skippable(item=self.no_offheap_memtables_test, include_no_offheap_memtables_tests=False)
+    @pytest.mark.parametrize("config, sufficient_resources",
+                             [("", False),
+                              ("skip_resource_intensive_tests", True),
+                              ("skip_resource_intensive_tests", False)])
+    def test_skip_resource_intensive(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert is_skippable(self.resource_intensive_test,
+                            SkipConditions(dtest_config, sufficient_resources))
 
-    def test_depends_driver_test(self):
-        assert _is_skippable(item=self.depends_driver_test)
+    @pytest.mark.parametrize("config", ["force_execution_of_resource_intensive_tests",
+                                        "only_resource_intensive_tests"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_include_resource_intensive_if_any_resources(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert not is_skippable(self.resource_intensive_test, SkipConditions(
+            dtest_config, sufficient_resources))
+
+    def test_skip_resource_intensive_wins(self):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("force_execution_of_resource_intensive_tests")
+        dtest_config.set("only_resource_intensive_tests")
+        dtest_config.set("skip_resource_intensive_tests")
+        assert is_skippable(self.resource_intensive_test,
+                            SkipConditions(dtest_config, True))
+
+    @pytest.mark.parametrize("item",
+                             [regular_test, resource_intensive_test, vnodes_test,
+                              no_offheap_memtables_test])
+    def test_if_config_vnodes(self, item):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("use_vnodes")
+        assert not is_skippable(item, SkipConditions(dtest_config, True))
+
+    def test_skip_no_offheap_memtables(self):
+        dtest_config = DTestConfigMock()
+        dtest_config.set("use_off_heap_memtables")
+        assert is_skippable(self.no_offheap_memtables_test,
+                            SkipConditions(dtest_config, True))
+
+    @pytest.mark.parametrize("config", ["", "execute_upgrade_tests", "execute_upgrade_tests_only",
+                                        "force_execution_of_resource_intensive_tests",
+                                        "only_resource_intensive_tests",
+                                        "skip_resource_intensive_tests", "use_vnodes",
+                                        "use_off_heap_memtables"])
+    @pytest.mark.parametrize("sufficient_resources", [True, False])
+    def test_skip_depends_driver_always(self, config, sufficient_resources):
+        dtest_config = DTestConfigMock()
+        dtest_config.set(config)
+        assert is_skippable(self.depends_driver_test, SkipConditions(
+            dtest_config, sufficient_resources))

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -188,6 +188,7 @@ class TestPagingSize(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(pf.all_data(), expected_data, sort_key='value')
 
 
+@pytest.mark.upgrade_test
 class TestPagingWithModifiers(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when CQL modifiers (such as order, limit, allow filtering) are used.
@@ -916,6 +917,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(expected_data, pf.all_data(), sort_key='sometext')
 
 
+@pytest.mark.upgrade_test
 class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when the queried dataset changes while pages are being retrieved.
@@ -1107,6 +1109,7 @@ class TestPagingDatasetChanges(BasePagingTester, PageAssertionMixin):
             assert_lists_equal_ignoring_order(page3, page3expected, sort_key="mytext")
 
 
+@pytest.mark.upgrade_test
 class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with isolation of paged queries (queries can't affect each other).
@@ -1196,6 +1199,7 @@ class TestPagingQueryIsolation(BasePagingTester, PageAssertionMixin):
             self.assertEqualIgnoreOrder(flatten_into_set(page_fetchers[10].all_data()), flatten_into_set(expected_data[:50000]))
 
 
+@pytest.mark.upgrade_test
 class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
     """
     Tests concerned with paging when deletions occur.


### PR DESCRIPTION
This commit fixes few unexpected behaviors, which were:
1. If any test class is marked with `resource_intensive`, then all tests
   in the file were treated as resource intensive.
2. If one test class is marked with `vnodes` and another test class is
   marked with `no_vnodes` in the same file, then all tests were
   skipped in the file.
3. If a test run is executed with the argument
   `--only-resource-intensive-tests` and there is no sufficient
   resources for resource intensive tests, then no tests were executed.
   Thus it was necessary to provide `-force-resource-intensive-tests`
   in addition.

The unexpected behaviors 1 and 2 are due to marking all tests in a
file if any class is assigned the mark.

As the result of this commit:
- Marks on other classes in the file do not affect a test, which is
  not marked and neither its class. This is also applied to upgrade
  tests, so the code is simplified and behavior is unified.
- `--only-resource-intensive-tests` does not require sufficient
  resources any more, so specifying it will execute only resource
  intensive tests independently on available resources.

Since after the fix marking needs to be done on every class in the
file if tests are expected to be marked, the files with upgrade tests
are fixed to mark each included test class if at least one class is
marked.

The unit tests of `is_shippable` from `conftest.py` are changed to test
calculating skipping conditions from provided mocked configurations
instead of shipping if conditions are satisfied or not, which required
to change the underlying implementation. The unit tests are also
rewritten to be parameterized and it covers now all possible meaningful
test cases.