### PR TITLE
STAR-822: Update test_consistent_repair dtest

### DIFF
--- a/repair_tests/incremental_repair_test.py
+++ b/repair_tests/incremental_repair_test.py
@@ -143,38 +143,20 @@ class TestIncRepair(Tester):
             results = list(session.execute("SELECT * FROM system.repairs"))
             assert len(results) == 0, str(results)
 
-        # disable compaction so we can verify sstables are marked pending repair
-        for node in self.cluster.nodelist():
-            node.nodetool('disableautocompaction ks tbl')
-
+        # repair
         node1.repair(options=['ks'])
 
         # check that all participating nodes have the repair recorded in their system
         # table, that all nodes are listed as participants, and that all sstables are
         # (still) marked pending repair
         expected_participants = {n.address() for n in self.cluster.nodelist()}
-        expected_participants_wp = {n.address_and_port() for n in self.cluster.nodelist()}
-        recorded_pending_ids = set()
         for node in self.cluster.nodelist():
             session = self.patient_exclusive_cql_connection(node)
             results = list(session.execute("SELECT * FROM system.repairs"))
             assert len(results) == 1
             result = results[0]
             assert set(result.participants) == expected_participants
-            if hasattr(result, "participants_wp"):
-                assert set(result.participants_wp) == expected_participants_wp
-            assert result.state, ConsistentState.FINALIZED == "4=FINALIZED"
-            pending_id = result.parent_id
-            self.assertAllPendingRepairSSTables(node, 'ks', pending_id)
-            recorded_pending_ids.add(pending_id)
-
-        assert len(recorded_pending_ids) == 1
-
-        # sstables are compacted out of pending repair by a compaction
-        # task, we disabled compaction earlier in the test, so here we
-        # force the compaction and check that all sstables are promoted
-        for node in self.cluster.nodelist():
-            node.nodetool('compact ks tbl')
+            assert result.state == ConsistentState.FINALIZED, str(result.state)
             self.assertAllRepairedSSTables(node, 'ks')
 
     def test_sstable_marking(self):


### PR DESCRIPTION
In DB-4215 compaction has been separated from repairs and that separation seems to be pulled from DSE along with UCS. Therefore, checking for the repair status depending on whether compaction was run or not is nor relevant any longer.

This commit updates the test_consistent_repair to the version we have in apollo-dtest.