### PR TITLE
STAR-899 Fix class name used from SchemaManager to Schema

### DIFF
--- a/byteman/merge_schema_failure_4x.btm
+++ b/byteman/merge_schema_failure_4x.btm
@@ -2,7 +2,7 @@
 # Inject node failure on merge schema exit.
 #
 RULE inject node failure on merge schema exit
-CLASS org.apache.cassandra.schema.SchemaManager
+CLASS org.apache.cassandra.schema.Schema
 METHOD mergeAndUpdateVersion
 AT EXIT
 # set flag to only run this rule once.


### PR DESCRIPTION
In build [ds-cassandra-build-nightly/575](https://jenkins-stargazer.build.dsinternal.org/job/ds-cassandra-build-nightly/575/testReport/dtest-offheap-bti.materialized_views_test/TestMaterializedViews/tests_stage_2___dtests___dtest_offheap_bti___dtest_offheap_bti_36___test_rename_column_atomicity/), the subject test passes with this change:
```
Passed
tests-stage-2 / dtests / dtest-offheap-bti / dtest-offheap-bti-36 / dtest-offheap-bti.materialized_views_test.TestMaterializedViews.test_rename_column_atomicity (from Cassandra dtests)
```
