### PR TITLE
CNDB-9974: Fix tests for CASSANDRA-18252 - removal of scripted UDFs

### DIFF
--- a/auth_test.py
+++ b/auth_test.py
@@ -1229,7 +1229,7 @@ class TestAuthRoles(AbstractTestAuth):
         @jira_ticket CASSANDRA-7653
         """
         dtest_setup_overrides = DTestSetupOverrides()
-        if '3.0' <= dtest_config.cassandra_version_from_build < '4.2':
+        if '3.0' <= dtest_config.cassandra_version_from_build < '4.0':
             dtest_setup_overrides.cluster_options = ImmutableMapping({'enable_user_defined_functions': 'true',
                                                                       'enable_scripted_user_defined_functions': 'true'})
         else:
@@ -1401,7 +1401,7 @@ class TestAuthRoles(AbstractTestAuth):
         as_mike.execute("CREATE KEYSPACE ks WITH replication = {'class':'SimpleStrategy', 'replication_factor':1}")
         as_mike.execute("CREATE TABLE ks.cf (id int primary key, val int)")
         as_mike.execute("CREATE ROLE role1 WITH PASSWORD = '11111' AND SUPERUSER = false AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             as_mike.execute("""CREATE FUNCTION ks.state_function_1(a int, b int)
                             CALLED ON NULL INPUT
                             RETURNS int
@@ -1698,7 +1698,7 @@ class TestAuthRoles(AbstractTestAuth):
         self.superuser.execute("CREATE TABLE ks.cf (id int primary key, val int)")
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND SUPERUSER = false AND LOGIN = true")
         self.superuser.execute("CREATE ROLE role1 WITH SUPERUSER = false AND LOGIN = false")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.state_func(a int, b int) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'a+b'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.state_func(a int, b int) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS ' return a+b;'")
@@ -2180,7 +2180,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
             self.superuser.execute("CREATE FUNCTION ks.\"plusOne\" ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
@@ -2229,7 +2229,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")
@@ -2260,7 +2260,7 @@ class TestAuthRoles(AbstractTestAuth):
         self.superuser.execute("INSERT INTO ks.t1 (k,v) values (1,1)")
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
         self.superuser.execute("GRANT SELECT ON ks.t1 TO mike")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.func_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
             self.superuser.execute("CREATE FUNCTION ks.func_two ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
@@ -2319,7 +2319,7 @@ class TestAuthRoles(AbstractTestAuth):
         * Verify mike can create a new UDF iff he has the CREATE permission
         """
         self.setup_table()
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")
@@ -2327,7 +2327,7 @@ class TestAuthRoles(AbstractTestAuth):
         as_mike = self.get_session(user='mike', password='12345')
 
         # can't replace an existing function without ALTER permission on the parent ks
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             cql = "CREATE OR REPLACE FUNCTION ks.plus_one( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript as '1 + input'"
         else:
             cql = "CREATE OR REPLACE FUNCTION ks.plus_one( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java as 'return 1 + input;'"
@@ -2370,7 +2370,7 @@ class TestAuthRoles(AbstractTestAuth):
                        InvalidRequest)
 
         # can't create a new function without CREATE on the parent keyspace's collection of functions
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             cql = "CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'"
         else:
             cql = "CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'"
@@ -2390,7 +2390,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")
@@ -2421,7 +2421,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else: 
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")
@@ -2452,7 +2452,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input double ) CALLED ON NULL INPUT RETURNS double LANGUAGE javascript AS 'input + 1'")
         else:
@@ -2499,7 +2499,7 @@ class TestAuthRoles(AbstractTestAuth):
         """
         self.setup_table()
         self.superuser.execute("CREATE ROLE mike WITH PASSWORD = '12345' AND LOGIN = true")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.state_func (a int, b int) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'a + b'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.state_func (a int, b int) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return a + b;'")
@@ -2555,7 +2555,7 @@ class TestAuthRoles(AbstractTestAuth):
         @param cql The statement to verify. Should contain the UDF ks.plus_one
         """
         self.setup_table()
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")
@@ -2579,7 +2579,7 @@ class TestAuthRoles(AbstractTestAuth):
         self.setup_table()
         self.superuser.execute("CREATE ROLE function_user")
         self.superuser.execute("GRANT EXECUTE ON ALL FUNCTIONS IN KEYSPACE ks TO function_user")
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE javascript AS 'input + 1'")
         else:
             self.superuser.execute("CREATE FUNCTION ks.plus_one ( input int ) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return input + 1;'")

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -107,7 +107,7 @@ class TestCqlsh(Tester, CqlshMixin):
     def fixture_dtest_setup_overrides(self, dtest_config):
         dtest_setup_overrides = DTestSetupOverrides()
 
-        if '3.0' <= dtest_config.cassandra_version_from_build < '4.2':
+        if '3.0' <= dtest_config.cassandra_version_from_build < '4.0':
             dtest_setup_overrides.cluster_options = ImmutableMapping({'enable_user_defined_functions': 'true',
                                                                       'enable_scripted_user_defined_functions': 'true'})
         else:

--- a/schema_metadata_test.py
+++ b/schema_metadata_test.py
@@ -503,7 +503,7 @@ class TestSchemaMetadata(Tester):
         cluster = fixture_dtest_setup.cluster
         cluster.schema_event_refresh_window = 0
 
-        if cluster.version() >= '4.2':
+        if cluster.version() >= '4.0':
             cluster.set_configuration_options({'enable_user_defined_functions': 'true'})
         elif cluster.version() >= '3.0':
             cluster.set_configuration_options({'enable_user_defined_functions': 'true',

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -528,7 +528,8 @@ class TestUpgrade(Tester):
             logger.debug("Set new cassandra dir for %s: %s" % (node.name, node.get_install_dir()))
             if internode_ssl and (LooseVersion(version_meta.family) >= CASSANDRA_4_0):
                 node.set_configuration_options({'server_encryption_options': {'enabled': True, 'enable_legacy_ssl_storage_port': True}})
-            if LooseVersion(version_meta.family) >= CASSANDRA_5_0:
+
+            if LooseVersion(version_meta.family) >= CASSANDRA_4_0:
                 # only clusters starting from <5.0 will have enable_scripted_user_defined_functions=true
                 node.set_configuration_options({'enable_scripted_user_defined_functions': 'false'})
 
@@ -781,7 +782,7 @@ class BootstrapMixin(object):
         logger.debug("Adding a node to the cluster")
         nnode = new_node(self.cluster, remote_debug_port=str(2000 + len(self.cluster.nodes)))
 
-        if nnode.get_cassandra_version() >= '4.2':
+        if nnode.get_cassandra_version() >= '4.0':
             nnode.set_configuration_options({'enable_scripted_user_defined_functions': 'false'})
 
         nnode.start(use_jna=True, wait_other_notice=240, wait_for_binary_proto=True)
@@ -795,7 +796,7 @@ class BootstrapMixin(object):
         logger.debug("Adding a node to the cluster")
         nnode = new_node(self.cluster, remote_debug_port=str(2000 + len(self.cluster.nodes)), data_center='dc2')
 
-        if nnode.get_cassandra_version() >= '4.2':
+        if nnode.get_cassandra_version() >= '4.0':
             nnode.set_configuration_options({'enable_scripted_user_defined_functions': 'false'})
 
         nnode.start(use_jna=True, wait_other_notice=240, wait_for_binary_proto=True)

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -170,7 +170,7 @@ class TestUserFunctions(Tester):
         # should now work - unambiguous
         session.execute("DROP FUNCTION overloaded")
 
-    @since('3.0', max_version='4.0.x')
+    @since('3.0', max_version='3.11.x')
     def test_udf_scripting(self):
         session = self.prepare()
         session.execute("create table nums (key int primary key, val double);")

--- a/user_functions_test.py
+++ b/user_functions_test.py
@@ -24,7 +24,7 @@ class TestUserFunctions(Tester):
     def fixture_dtest_setup_overrides(self, dtest_config):
         dtest_setup_overrides = DTestSetupOverrides()
 
-        if '3.0' <= dtest_config.cassandra_version_from_build < '4.2':
+        if '3.0' <= dtest_config.cassandra_version_from_build < '4.0':
             dtest_setup_overrides.cluster_options = ImmutableMapping({'enable_user_defined_functions': 'true',
                                                                       'enable_scripted_user_defined_functions': 'true'})
         else:
@@ -147,7 +147,7 @@ class TestUserFunctions(Tester):
         session.execute("CREATE OR REPLACE FUNCTION overloaded(v ascii) called on null input RETURNS text LANGUAGE java AS 'return \"f1\";'")
 
         # ensure that works with correct specificity
-        if self.cluster.version() < LooseVersion('4.1'):
+        if self.cluster.version() < LooseVersion('4.0'):
             assert_invalid(session, "SELECT v FROM tab WHERE k = overloaded('foo')")
         else:
             assert_none(session, "SELECT v FROM tab WHERE k = overloaded('foo')")
@@ -170,7 +170,7 @@ class TestUserFunctions(Tester):
         # should now work - unambiguous
         session.execute("DROP FUNCTION overloaded")
 
-    @since('3.0', max_version='4.1.x')
+    @since('3.0', max_version='4.0.x')
     def test_udf_scripting(self):
         session = self.prepare()
         session.execute("create table nums (key int primary key, val double);")
@@ -211,7 +211,7 @@ class TestUserFunctions(Tester):
         assert_one(session, "SELECT avg(val) FROM nums", [5.0])
         assert_one(session, "SELECT count(*) FROM nums", [9])
 
-        if self.cluster.version() < LooseVersion('4.2'):
+        if self.cluster.version() < LooseVersion('4.0'):
             session.execute("create function test(a int, b double) called on null input returns int language javascript as 'a + b;'")
         else:
             session.execute("create function test(a int, b double) called on null input returns int language java as 'return a + Integer.valueOf(b.intValue());'")


### PR DESCRIPTION
The ticket also fixes STAR-1886. Backporting CASSANDRA-17190 required also CASSANDRA-17383.

DRAFT as it needs manual submit of CI  tests pre-commit, working on that (PR gate CI run will fail as it will run CI with ds-trunk)
This patch needs to be committed together with the corresponding datastax/cassandra fix for CNDB-9974.
The order of commit needs to be (so CI can run without failing many tests):
1) DTest patch
2) cassandra patch
