### PR TITLE
CNDB-10152: Fix Python DTests - update pytest.fail() and skip() for newer pytest versions

### DIFF
--- a/compaction_test.py
+++ b/compaction_test.py
@@ -605,11 +605,11 @@ class TestCompaction(Tester):
 
     def skip_if_no_major_compaction(self, strategy):
         if self.cluster.version() < '2.2' and strategy == 'LeveledCompactionStrategy':
-            pytest.skip(msg='major compaction not implemented for LCS in this version of Cassandra')
+            pytest.skip('major compaction not implemented for LCS in this version of Cassandra')
 
     def skip_if_not_supported(self, strategy):
         if self.cluster.version() >= '5.0' and strategy == 'DateTieredCompactionStrategy':
-            pytest.skip(msg='DateTieredCompactionStrategy is not supported in Cassandra 5.0 and later')
+            pytest.skip('DateTieredCompactionStrategy is not supported in Cassandra 5.0 and later')
 
 def grep_sstables_in_each_level(node, table_name):
     output = node.nodetool('cfstats').stdout

--- a/conftest.py
+++ b/conftest.py
@@ -370,7 +370,7 @@ def fixture_dtest_setup(request,
             errors = check_logs_for_errors(dtest_setup)
             if len(errors) > 0:
                 failed = True
-                pytest.fail(msg='Unexpected error found in node logs (see stdout for full details). Errors: [{errors}]'
+                pytest.fail('Unexpected error found in node logs (see stdout for full details). Errors: [{errors}]'
                             .format(errors=str.join(", ", errors)), pytrace=False)
     finally:
         try:

--- a/mixed_version_test.py
+++ b/mixed_version_test.py
@@ -31,7 +31,7 @@ class TestSchemaChanges(Tester):
         elif original_version.vstring.startswith('2.1'):
             upgraded_version = 'github:apache/cassandra-2.2'
         else:
-            pytest.skip(msg="This test is only designed to work with 2.0 and 2.1 right now")
+            pytest.skip("This test is only designed to work with 2.0 and 2.1 right now")
 
         # start out with a major behind the previous version
 

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -1570,9 +1570,9 @@ class TestCQL(UpgradeTester):
 
             upgrade_to_version = self.get_node_version(is_upgraded=True)
             if LooseVersion('3.0.0') <= upgrade_to_version <= LooseVersion('3.0.6'):
-                pytest.skip(msg='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
+                pytest.skip('CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
             elif LooseVersion('3.1') <= upgrade_to_version <= LooseVersion('3.6'):
-                pytest.skip(msg='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
+                pytest.skip('CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
 
             session.execute("TRUNCATE ks.cf")
 


### PR DESCRIPTION
The issue can be reproduced by pinning the versions for packages we have installed in Jenkins in your local requirements.txt and reinstalling them by running `pip install -r requirements.txt`.

This is what I had for reproduction and testing locally:
```
diff --git a/requirements.txt b/requirements.txt
index e33975e9..cb90dd5f 100644
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,19 +10,19 @@
 # In case you want to test a patch with your own CCM branch, further to changing below CCM repo and branch name, you need to add -e flag at the beginning
 # Example: -e git+https://github.com/userb/ccm.git@cassandra-17182#egg=ccm
 git+https://github.com/riptano/ccm.git@converged-cassandra#egg=ccm
-decorator
-docopt
-enum34
-flaky
+decorator==5.1.1
+docopt==0.6.2
+enum34==1.1.10
+flaky==3.8.1
 mock
-pytest>=6.5.0
+pytest==8.2.2
 pytest-timeout==1.4.2
 pytest-repeat
 py
-parse
-pycodestyle
-psutil
-six>=1.12.0
+parse==1.20.2
+pycodestyle==2.12.0
+psutil==6.0.0
+six==1.16.0
 thrift==0.10.0
 netifaces
 beautifulsoup4
```

Leaving the PR as draft until I finish new round of Jenkins testing to confirm there were no more places to fix. 