### PR TITLE
CNDB-10152: Fix Python DTests calls to pytest.fail() and skip() for n…

### DIFF
--- a/bootstrap_test.py
+++ b/bootstrap_test.py
@@ -987,7 +987,7 @@ class BootstrapTester(Tester):
 
         try:
             node2.nodetool('join')
-            pytest.fail('nodetool should have errored and failed to join ring')
+            pytest.fail(reason='nodetool should have errored and failed to join ring')
         except ToolError as t:
             assert "Cannot join the ring until bootstrap completes" in t.stdout
 
@@ -1012,7 +1012,7 @@ class BootstrapTester(Tester):
 
         try:
             node3.nodetool('join')
-            pytest.fail('nodetool should have errored and failed to join ring')
+            pytest.fail(reason='nodetool should have errored and failed to join ring')
         except ToolError as t:
             assert "Cannot join the ring until bootstrap completes" in t.stdout
 

--- a/compaction_test.py
+++ b/compaction_test.py
@@ -218,7 +218,7 @@ class TestCompaction(Tester):
         self.skip_if_not_supported(strategy)
 
         if strategy != 'DateTieredCompactionStrategy':
-            pytest.skip('Not implemented unless DateTieredCompactionStrategy is used')
+            pytest.skip(reason='Not implemented unless DateTieredCompactionStrategy is used')
 
         cluster = self.cluster
         cluster.populate(1).start()
@@ -561,7 +561,7 @@ class TestCompaction(Tester):
         @jira_ticket CASSANDRA-11550
         """
         if not hasattr(self, 'strategy') or strategy != 'LeveledCompactionStrategy':
-            pytest.skip('Not implemented unless LeveledCompactionStrategy is used')
+            pytest.skip(reason='Not implemented unless LeveledCompactionStrategy is used')
 
         cluster = self.cluster
         cluster.populate(1).start()
@@ -605,11 +605,11 @@ class TestCompaction(Tester):
 
     def skip_if_no_major_compaction(self, strategy):
         if self.cluster.version() < '2.2' and strategy == 'LeveledCompactionStrategy':
-            pytest.skip(msg='major compaction not implemented for LCS in this version of Cassandra')
+            pytest.skip(reason='major compaction not implemented for LCS in this version of Cassandra')
 
     def skip_if_not_supported(self, strategy):
         if self.cluster.version() >= '5.0' and strategy == 'DateTieredCompactionStrategy':
-            pytest.skip(msg='DateTieredCompactionStrategy is not supported in Cassandra 5.0 and later')
+            pytest.skip(reason='DateTieredCompactionStrategy is not supported in Cassandra 5.0 and later')
 
 def grep_sstables_in_each_level(node, table_name):
     output = node.nodetool('cfstats').stdout

--- a/conftest.py
+++ b/conftest.py
@@ -370,7 +370,7 @@ def fixture_dtest_setup(request,
             errors = check_logs_for_errors(dtest_setup)
             if len(errors) > 0:
                 failed = True
-                pytest.fail(msg='Unexpected error found in node logs (see stdout for full details). Errors: [{errors}]'
+                pytest.fail(reason='Unexpected error found in node logs (see stdout for full details). Errors: [{errors}]'
                             .format(errors=str.join(", ", errors)), pytrace=False)
     finally:
         try:

--- a/mixed_version_test.py
+++ b/mixed_version_test.py
@@ -31,7 +31,7 @@ class TestSchemaChanges(Tester):
         elif original_version.vstring.startswith('2.1'):
             upgraded_version = 'github:apache/cassandra-2.2'
         else:
-            pytest.skip(msg="This test is only designed to work with 2.0 and 2.1 right now")
+            pytest.skip(reason="This test is only designed to work with 2.0 and 2.1 right now")
 
         # start out with a major behind the previous version
 

--- a/native_transport_ssl_test.py
+++ b/native_transport_ssl_test.py
@@ -36,7 +36,7 @@ class TestNativeTransportSSL(Tester):
         try:  # hack around assertRaise's lack of msg parameter
             # try to connect without ssl options
             self.patient_cql_connection(node1)
-            pytest.fail('Should not be able to connect to SSL socket without SSL enabled client')
+            pytest.fail(reason='Should not be able to connect to SSL socket without SSL enabled client')
         except NoHostAvailable:
             pass
 
@@ -78,7 +78,7 @@ class TestNativeTransportSSL(Tester):
         cluster.start()
         try:  # hack around assertRaise's lack of msg parameter
             self.patient_cql_connection(node1)
-            pytest.fail('Should not be able to connect to non-default port')
+            pytest.fail(reason='Should not be able to connect to non-default port')
         except NoHostAvailable:
             pass
 

--- a/offline_tools_test.py
+++ b/offline_tools_test.py
@@ -355,7 +355,7 @@ class TestOfflineTools(Tester):
             #   Error opening zip file or JAR manifest missing : /home/mshuler/git/cassandra/lib/jamm-0.2.5.jar
             # The 2.1 installed jamm version is 0.3.0, but bin/cassandra.in.sh used by nodetool still has 0.2.5
             # (when this is fixed in CCM issue #463, install version='github:apache/cassandra-2.0' as below)
-            pytest.skip('Skipping 2.1 test due to jamm.jar version upgrade problem in CCM node configuration.')
+            pytest.skip(reason='Skipping 2.1 test due to jamm.jar version upgrade problem in CCM node configuration.')
         elif testversion < '3.0':
             logger.debug('Test version: {} - installing github:apache/cassandra-2.1'.format(testversion))
             cluster.set_install_dir(version='github:apache/cassandra-2.1')

--- a/paging_test.py
+++ b/paging_test.py
@@ -3458,7 +3458,7 @@ class TestPagingWithDeletions(BasePagingTester, PageAssertionMixin):
         except Exception:
             raise
         else:
-            pytest.fail('Expected ReadFailure or ReadTimeout, depending on the cluster version')
+            pytest.fail(reason='Expected ReadFailure or ReadTimeout, depending on the cluster version')
 
         if self.cluster.version() < "3.0":
             failure_msg = ("Scanned over.* tombstones in test_paging_size."

--- a/pushed_notifications_test.py
+++ b/pushed_notifications_test.py
@@ -436,7 +436,7 @@ class TestVariousNotifications(Tester):
             except Exception:
                 raise
             else:
-                pytest.fail('Expected ReadFailure')
+                pytest.fail(reason='Expected ReadFailure')
 
         read_failure_query()
 
@@ -468,7 +468,7 @@ class TestVariousNotifications(Tester):
             except Exception:
                 raise
             else:
-                pytest.fail('Expected ReadFailure')
+                pytest.fail(reason='Expected ReadFailure')
 
         range_request_failure_query()
 

--- a/rebuild_test.py
+++ b/rebuild_test.py
@@ -227,7 +227,7 @@ class TestRebuild(Tester):
             logger.debug('Checking data is complete -> '),
             for i in range(0, 20000):
                 query_c1c2(session, i, ConsistencyLevel.LOCAL_ONE)
-            pytest.fail('Expected: INCOMPLETE')
+            pytest.fail(reason='Expected: INCOMPLETE')
 
         logger.debug('Executing second rebuild -> '),
         node3.nodetool('rebuild dc1')

--- a/replica_side_filtering_test.py
+++ b/replica_side_filtering_test.py
@@ -103,11 +103,11 @@ class ReplicaSideFiltering(Tester):
 
     def _skip_if_index_on_static_is_not_supported(self):
         if self.create_index() and self.cluster.version() < '3.4':
-            pytest.skip('Secondary indexes on static column are not supported before 3.4 (CASSANDRA-8103)')
+            pytest.skip(reason='Secondary indexes on static column are not supported before 3.4 (CASSANDRA-8103)')
 
     def _skip_if_filtering_partition_columns_is_not_supported(self):
         if not self.create_index() and self.cluster.version() < '3.11':
-            pytest.skip('Filtering of partition key parts is not supported before 3.11 (CASSANDRA-13275)')
+            pytest.skip(reason='Filtering of partition key parts is not supported before 3.11 (CASSANDRA-13275)')
 
     @abstractmethod
     def create_index(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ docopt
 enum34
 flaky
 mock
-pytest>=6.5.0
+pytest>=8.2.2
 pytest-timeout==1.4.2
 pytest-repeat
 py

--- a/upgrade_tests/cql_tests.py
+++ b/upgrade_tests/cql_tests.py
@@ -88,7 +88,7 @@ class TestCQL(UpgradeTester):
         """ For large collections, make sure that we are printing warnings """
         for version in self.get_node_versions():
             if version >= '3.0':
-                pytest.skip('version {} not compatible with protocol version 2'.format(version))
+                pytest.skip(reason='version {} not compatible with protocol version 2'.format(version))
 
         # We only warn with protocol 2
         cursor = self.prepare(protocol_version=2)
@@ -1570,9 +1570,9 @@ class TestCQL(UpgradeTester):
 
             upgrade_to_version = self.get_node_version(is_upgraded=True)
             if LooseVersion('3.0.0') <= upgrade_to_version <= LooseVersion('3.0.6'):
-                pytest.skip(msg='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
+                pytest.skip(reason='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
             elif LooseVersion('3.1') <= upgrade_to_version <= LooseVersion('3.6'):
-                pytest.skip(msg='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
+                pytest.skip(reason='CASSANDRA-11930 was fixed in 3.0.7 and 3.7')
 
             session.execute("TRUNCATE ks.cf")
 

--- a/upgrade_tests/paging_test.py
+++ b/upgrade_tests/paging_test.py
@@ -660,7 +660,7 @@ class TestPagingData(BasePagingTester, PageAssertionMixin):
             min_version = min(self.get_node_versions())
             latest_version_with_bug = '2.2.3'
             if min_version <= latest_version_with_bug:
-                pytest.skip('known bug released in {latest_ver} and earlier (current min version {min_ver}); '
+                pytest.skip(reason='known bug released in {latest_ver} and earlier (current min version {min_ver}); '
                                'skipping'.format(latest_ver=latest_version_with_bug, min_ver=min_version))
 
             logger.debug("Querying %s node" % ("upgraded" if is_upgraded else "old",))

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -165,7 +165,7 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
                         "max version {}".format(new_version_from_build, self.max_version))
 
         if (new_version_from_build >= '3' and self.protocol_version is not None and self.protocol_version < 3):
-            pytest.skip('Protocol version {} incompatible '
+            pytest.skip(reason='Protocol version {} incompatible '
                         'with Cassandra version {}'.format(self.protocol_version, new_version_from_build))
         node1.set_log_level(logging.getLevelName(logging.root.level))
         node1.set_configuration_options(values={'internode_compression': 'none'})


### PR DESCRIPTION
…ewer pytest versions. Pin lowest expected pytest version in requirements.txt

New PR with only the changes against ds-trunk.
Based on discussion with the reviewer  - we pinned minimum version for Pytest.
I will close the previous PR - https://github.com/datastax/cassandra-dtest/pull/71 It was including the tests for #9974.
Here we test directly against main and ds-trunk:
https://jenkins-stargazer.aws.dsinternal.org/view/cc-builds/job/ds-cassandra-build/735/

CC @JeremiahDJordan 