### PR TITLE
CNDB-12226 Fix test_atomic_writes that broke after CNDB-11242

### DIFF
--- a/read_repair_test.py
+++ b/read_repair_test.py
@@ -823,7 +823,8 @@ class TestReadRepairGuarantees(Tester):
                                                   'dynamic_snitch': False,
                                                   'write_request_timeout_in_ms': 500,
                                                   'read_request_timeout_in_ms': 500})
-        cluster.populate(3, install_byteman=True, debug=True).start(jvm_args=['-XX:-PerfDisableSharedMem'])
+        cluster.populate(3, install_byteman=True, debug=True).start(jvm_args=['-XX:-PerfDisableSharedMem',
+                                                                              '-Dcassandra.cluster_version_provider.min_stable_duration_ms=0'])
         session = fixture_dtest_setup.patient_exclusive_cql_connection(cluster.nodelist()[0], timeout=2)
 
         session.execute("CREATE KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")


### PR DESCRIPTION
This PR fixes read_repair_test.TestReadRepairGuarantees.test_atomic_writes[blocking]

The change made is to set the system property `ccassandra.cluster_version_provider.min_stable_duration_ms=0`. This property is defined in `CassandraRelevantProperties` with description:
> Minimum time that needs to pass after the cluster is detected as fully upgraded to report that there is no upgrade in progress (when using the default cluster version provider).

Without this change the cluster will appear to be upgrading, and that causes `ColumnFilter.isUpgradingFromVersionLowerThan[version]` methods to return `true` and break the test behavior. 

This test has been broken since [CNDB-11242](https://github.com/riptano/cndb/issues/11242) in PR https://github.com/datastax/cassandra/pull/1458 that made changes to `Gossiper`. In relation to this test,  `Gossiper.isUpgradingFromVersionLowerThan` will return `true` if the cluster is not yet considered fully upgraded, and in turn the `ColumnFilter.isUpgradingFromVersionLowerThan` will return `true`, causing the `ColumnFilter` to take the wrong decisions needed for this test.
