### PR TITLE
HCD-120 – Add upgrade paths to cc, from C* and dse

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -457,13 +457,19 @@ def fixture_since(request, fixture_dtest_setup):
                 skip_msg = _skip_msg(LooseVersion(upgrade_path.upgrade_meta.family), since, max_version)
                 if skip_msg:
                     pytest.skip(skip_msg)
-            ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.starting_meta.version)
-            starting_version = get_version_from_build(ccm_repo_cache_dir)
+            if 'current' == upgrade_path.starting_meta.variant:
+                starting_version = LooseVersion(upgrade_path.starting_meta.version)
+            else:
+                ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.starting_meta.version)
+                starting_version = get_version_from_build(ccm_repo_cache_dir)
             skip_msg = _skip_msg(starting_version, since, max_version)
             if skip_msg:
                 pytest.skip(skip_msg)
-            ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.upgrade_meta.version)
-            ending_version = get_version_from_build(ccm_repo_cache_dir)
+            if 'current' == upgrade_path.upgrade_meta.variant:
+                ending_version = LooseVersion(upgrade_path.upgrade_meta.version)
+            else:
+                ccm_repo_cache_dir, _ = ccmlib.repository.setup(upgrade_path.upgrade_meta.version)
+                ending_version = get_version_from_build(ccm_repo_cache_dir)
             skip_msg = _skip_msg(ending_version, since, max_version)
             if skip_msg:
                 pytest.skip(skip_msg)

--- a/upgrade_tests/upgrade_base.py
+++ b/upgrade_tests/upgrade_base.py
@@ -9,10 +9,9 @@ import time
 
 from abc import ABCMeta
 
-from ccmlib import extension, repository
-from ccmlib.common import get_version_from_build, is_win
+from ccmlib.common import get_available_jdk_versions, get_jdk_version_int, get_version_from_build, is_win, update_java_version
 
-from .upgrade_manifest import CASSANDRA_4_0
+from .upgrade_manifest import CASSANDRA_4_0, get_cluster_class
 
 from dtest import Tester, create_ks
 
@@ -45,6 +44,7 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
 
         fixture_dtest_setup.ignore_log_patterns = fixture_dtest_setup.ignore_log_patterns + [
             r'RejectedExecutionException.*ThreadPoolExecutor has shut down',  # see  CASSANDRA-12364
+            r'Collectd is only supported on Linux',
         ]
 
     @pytest.fixture(autouse=True)
@@ -87,14 +87,18 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
 
         cluster = self.cluster
 
+        self.reinit_cluster_for_family(self.UPGRADE_PATH.starting_meta)
+
+        # if current jdk is not compatible with starting_version, use the highest available JDK version that is
+        if get_jdk_version_int() not in self.UPGRADE_PATH.starting_meta.java_versions:
+            available__starting_versions = [v for v in get_available_jdk_versions(os.environ) if v in self.UPGRADE_PATH.starting_meta.java_versions]
+            if available__starting_versions:
+                update_java_version(jvm_version=available__starting_versions[-1])
+            else:
+                raise AssertionError("No overlapping versions found between available_versions {} and starting_meta.java_versions {}"
+                                 .format(available__starting_versions, self.UPGRADE_PATH.starting_meta.java_versions))
+
         cluster.set_install_dir(version=self.UPGRADE_PATH.starting_version)
-
-        install_dir_class = extension.get_cluster_class(cluster.get_install_dir())
-        if cluster.__class__ != install_dir_class:
-            logger.info("changing cluster type to {} (from {} bc {})".format(install_dir_class, cluster.__class__, cluster.get_install_dir()))
-            cluster.__class__ = install_dir_class
-            cluster._cassandra_version = cluster.dse_username = cluster.dse_password = None
-
         self.install_nodetool_legacy_parsing()
         self.fixture_dtest_setup.reinitialize_cluster_for_different_version()
 
@@ -115,6 +119,13 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
 
         if extra_config_options:
             cluster.set_configuration_options(values=extra_config_options)
+
+        # XXX - improve when upgrade tests using authenticator|authorizer|role_manager are added and need values preserved/transformed
+        default_auth_values = {'authenticator': 'AllowAllAuthenticator', 'authorizer': 'AllowAllAuthorizer', 'role_manager': 'CassandraRoleManager'}
+        for option, supported_default_value in default_auth_values.items():
+            if option not in cluster._config_options or cluster._config_options[option] != supported_default_value:
+                logger.info("Setting {} from {} back to supported default of {}".format(option, cluster._config_options.get(option), supported_default_value))
+                cluster.set_configuration_options(values={option: supported_default_value})
 
         cluster.populate(nodes)
         cluster.start()
@@ -160,14 +171,9 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
             node1.mark_log_for_errors()
 
         logger.debug('upgrading node1 to {}'.format(self.UPGRADE_PATH.upgrade_version))
-        (install_dir, _) = repository.setup(self.UPGRADE_PATH.upgrade_version)
-        install_dir_class = extension.get_cluster_class(install_dir)
-        if self.cluster.__class__ != install_dir_class:
-            logger.info("changing cluster type to {} (from {} bc {})".format(install_dir_class, self.cluster.__class__, install_dir))
-            self.cluster.__class__ = install_dir_class
-            self.cluster._cassandra_version = self.cluster.dse_username = self.cluster.dse_password = None
+        if self.reinit_cluster_for_family(self.UPGRADE_PATH.upgrade_meta):
             old_conf = node1.get_conf_dir()
-            node1.__class__ = install_dir_class.getNodeClass()
+            node1.__class__ = self.cluster.getNodeClass()
             shutil.copytree(old_conf, node1.get_conf_dir())
 
         node1.set_install_dir(version=self.UPGRADE_PATH.upgrade_version)
@@ -269,3 +275,13 @@ class UpgradeTester(Tester, metaclass=ABCMeta):
     def upgrade_is_version_4_or_greater(self):
         upgrade_version = LooseVersion(self.upgrade_version_family())
         return upgrade_version >= CASSANDRA_4_0
+
+    def reinit_cluster_for_family(self, meta):
+        meta_family_class = get_cluster_class(meta.family)
+        if self.cluster.__class__ != meta_family_class:
+            logger.info("changing cluster type to {} (from {} bc {})".format(meta_family_class, self.cluster.__class__, meta))
+            self.cluster.__class__ = meta_family_class
+            # todo – move to `Cluster.reinit()` (so subclasses can reinit their own fields)
+            self.cluster._cassandra_version = self.cluster.dse_username = self.cluster.dse_password = self.cluster.opscenter = None
+            return True
+        return False

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -163,16 +163,16 @@ indev_2_2_x = VersionMeta(name='indev_2_2_x', family=CASSANDRA_2_2, variant='ind
 current_2_2_x = VersionMeta(name='current_2_2_x', family=CASSANDRA_2_2, variant='current', version='2.2.19', min_proto_v=1, max_proto_v=3, java_versions=(7, 8))
 
 indev_3_0_x = VersionMeta(name='indev_3_0_x', family=CASSANDRA_3_0, variant='indev', version='github:apache/cassandra-3.0', min_proto_v=3, max_proto_v=4, java_versions=(8,))
-current_3_0_x = VersionMeta(name='current_3_0_x', family=CASSANDRA_3_0, variant='current', version='3.0.30', min_proto_v=3, max_proto_v=4, java_versions=(8,))
+current_3_0_x = VersionMeta(name='current_3_0_x', family=CASSANDRA_3_0, variant='current', version='3.0.32', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 
 indev_3_11_x = VersionMeta(name='indev_3_11_x', family=CASSANDRA_3_11, variant='indev', version='github:apache/cassandra-3.11', min_proto_v=3, max_proto_v=4, java_versions=(8,))
-current_3_11_x = VersionMeta(name='current_3_11_x', family=CASSANDRA_3_11, variant='current', version='3.11.17', min_proto_v=3, max_proto_v=4, java_versions=(8,))
+current_3_11_x = VersionMeta(name='current_3_11_x', family=CASSANDRA_3_11, variant='current', version='3.11.19', min_proto_v=3, max_proto_v=4, java_versions=(8,))
 
 indev_4_0_x = VersionMeta(name='indev_4_0_x', family=CASSANDRA_4_0, variant='indev', version='github:apache/cassandra-4.0', min_proto_v=3, max_proto_v=4, java_versions=(8,11))
-current_4_0_x = VersionMeta(name='current_4_0_x', family=CASSANDRA_4_0, variant='current', version='4.0.15', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
+current_4_0_x = VersionMeta(name='current_4_0_x', family=CASSANDRA_4_0, variant='current', version='4.0.17', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
 
 indev_4_1_x = VersionMeta(name='indev_4_1_x', family=CASSANDRA_4_1, variant='indev', version='github:apache/cassandra-4.1', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
-current_4_1_x = VersionMeta(name='current_4_1_x', family=CASSANDRA_4_1, variant='current', version='4.1.7', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
+current_4_1_x = VersionMeta(name='current_4_1_x', family=CASSANDRA_4_1, variant='current', version='4.1.9', min_proto_v=4, max_proto_v=5, java_versions=(8,11))
 
 indev_5_0_x = VersionMeta(name='indev_5_0_x', family=CASSANDRA_5_0, variant='indev', version='github:apache/cassandra-5.0', min_proto_v=4, max_proto_v=5, java_versions=(11,17))
 current_5_0_x = VersionMeta(name='current_5_0_x', family=CASSANDRA_5_0, variant='current', version='5.0.4', min_proto_v=4, max_proto_v=5, java_versions=(11,17))


### PR DESCRIPTION

----
From https://datastax.jira.com/browse/HCD-120?focusedCommentId=734600

**Patch design notes.**

**The goal** here is to be able to run python dtest upgrade tests, using our downstream `datastax/` cassandra-ccm and cassandra-dtest codebases, while keeping them close to upstream `apache/` codebases.

CC's jenkins CI, and eventually HCD's CI, should be capable of running python dtest upgrade tests, and be run regularly. This ticket only address the framework of being able to run these tests, not plugging them into CI nor the overall test pass/failure rate of all the existing upgrade tests.

Our `datastax/cassandra-dtest` should include an upgrade manifest that enables the additional upgrade paths:

-   3.0.x → CC4
-   3.11.x → CC4
-   4.0.x → CC4
-   DSE 5.1.x → CC4
-   DSE 6.8.x → CC4
-   DSE 6.9.x → CC4

In the above list CC4 and the three DSE versions are "indev" variants, so upgrades from/to branch HEADs are made possible. The DSE versions may also have the "current" variants for testing against released versions, but this has not implemented in this round (and does not exist in apollo-dtests either -- it would require some extra code to handle dse versions, vs the `alias:bdp/`). CC4 does not have a "current" version, as releases for it don't exist. HCD will, but that is also planned for later round. ( There is commented code is in place to demonstrate this intention: `current_hcd_1_2 = VersionMeta(...)` )

In a later round we would add the additional upgrade paths:

-   3.0.x → HCD 1.2
-   3.11.x → HCD 1.2
-   4.0.x → HCD 1.2
-   HCD 1.2 → CC4
-   DSE 5.1.x → HCD 1.2
-   DSE 6.8.x → HCD 1.2
-   DSE 6.9.x → HCD 1.2

And later, for CC5, and with HCD 2.0 based off CC5, we would add:

-   4.0.x → CC5
-   CC4 → CC5
-   4.0.x → HCD 2.0
-   HCD 1.2 → CC5
-   HCD 1.2 → HCD 2.0

(Upgrades to HCD 2.0 directly from <4 or DSE 5.1.x won't be supported. Upgrades from DSE 6.8 and 6.9 are unknown, and should be considered likely not ever being supported.)

To make this possible, the following are needed:

-   HCD support in cassandra-ccm
-   Support switching product/cluster types on upgrade paths
-   Support switching between jvm versions, using `JAVAx_HOME`, on upgrade paths
-   Detect and use overlapping protocol versions

The 'HCD support in cassandra-ccm' was added in [CASSANDRA-20456](https://issues.apache.org/jira/browse/CASSANDRA-20456 "https://issues.apache.org/jira/browse/CASSANDRA-20456").

The remaining four patches are:

1.  Upstream cassandra-ccm: <https://github.com/apache/cassandra-ccm/pull/789>
    1.  improves cluster and node handling when determining the cassandra version from build directories,
    2.  better failure handling and messaging around the use of `generatetokens`
    3.  fix for dse nodes not having port specified in their addresses
2.  Downstream cassandra-ccm: <https://github.com/datastax/cassandra-ccm/pull/1>
    1.  the more complicated PR, as it's a rebase of the whole `converged-cassandra` branch (it will be forced pushed into place, not merged)
    2.  amends to the `a678224` commit to add converged core conditional logic, see [cassandra-ccm: //github Force usage of metadata_directory for converged cassandra (mck) added logic to check when converged](https://github.com/datastax/cassandra-ccm/pull/1/commits/3924e199543143dda14698d95ea784e480880e30)
    3.  manually adds `001b5ac` from CASSANDRA-20536, but this is expected to be just part of therebase, i.e. (a)
3.  Upstream cassandra-dtest: [https://github.com/apache/cassandra-dtest/pull/275/](https://github.com/apache/cassandra-dtest/pull/275/files "https://github.com/apache/cassandra-dtest/pull/275/files")
    1.  Fix places where we need to be using `cassandra_version()` (instead of just `version()`), now that we support other cluster types.
    2.  for upgrade tests default the protocol_version to the max of the source/starting version in the upgrade path -- the assumption here is that from.max_proto_v will always be within the to.min_proto_v to to.max_proto_v range.
    3.  for upgrade tests default the endpoint_snitch yaml property to SimpleSnitch. this relates to HCD-129
    4.  after upgrading a node, check and prune any unsupported config options
    5.  when creating a cluster (`dtest_setup.create_ccm_cluster(..)`) use the correct cluster type subclass
    6.  when upgrading, check (and change if necessary) the cluster class type and the node class type (and copy config files into new config locations)
4.  Downstream cassandra-dtest: [https://github.com/datastax/cassandra-dtest/pull/77/](https://github.com/datastax/cassandra-dtest/pull/77/files "https://github.com/datastax/cassandra-dtest/pull/77/files")
    1.  add new upgrade paths into the manifest
    2.  restore ability to use `JAVAx_HOME` env vars
    3.  simple fix for `cql_tracing_test.py`
 

This PR is (4).