### PR TITLE
CNDB-13838 Fix test_sstableloader_with_failing_2i to work with apache, CC4 and CC5

### DIFF
--- a/dtest_setup.py
+++ b/dtest_setup.py
@@ -390,6 +390,14 @@ class DTestSetup(object):
         return ((0 == len(self.cluster.nodelist()) or self.cluster.nodelist()[0].is_converged_core())
                 and self.cluster.version() >= LooseVersion('4.0') and self.cluster.version() < LooseVersion('5.0'))
 
+    def is_cc5(self):
+        """ Is this CC5
+
+        If there are nodes in the cluster, the first node is converged core and version 5.0.
+        """
+        return (0 < len(self.cluster.nodelist()) and self.cluster.nodelist()[0].is_converged_core()
+                and self.cluster.version() >= LooseVersion('5.0') and self.cluster.version() < LooseVersion('6.0'))
+
 
     def cleanup_last_test_dir(self):
         if os.path.exists(self.last_test_dir):

--- a/sstable_generation_loading_test.py
+++ b/sstable_generation_loading_test.py
@@ -462,7 +462,10 @@ class TestSSTableGenerationAndLoadingLegacyIndex(BaseSStableLoaderTester):
         # Check that the index isn't marked as built and the old SSTable data has been loaded but not indexed
         assert_none(session, """SELECT * FROM system."IndexInfo" WHERE table_name='k'""")
         assert_all(session, "SELECT * FROM k.t", [[0, 1, 8], [0, 2, 8]])
-        assert_unavailable(session.execute, "SELECT * FROM k.t WHERE v = 8")
+        if self.is_cc5():
+            assert_unavailable(session.execute, "SELECT * FROM k.t WHERE v = 8")
+        else:
+            assert_one(session, "SELECT * FROM k.t WHERE v = 8", [0, 2, 8])
 
         # Restart the node to trigger index rebuild
         node.nodetool('drain')


### PR DESCRIPTION
Fixes CNDB-13838: DTEST test failure: sstable_generation_loading_test.TestSSTableGenerationAndLoadingLegacyIndex.test_sstableloader_with_failing_2i

As noted in the gh issue, a previous changed fixed this test for CC 5.0, however then CC 4.0 `main` branch started failing.

This change introduces `DTestSetup::is_cc5()` and uses it to conditionally choose the appropriate assertion check in `test_sstableloader_with_failing_2i`.

I tested against Apache C* 5.04, CC4, and CC5 and all passed.
