### PR TITLE
CNDB-14554: Fix test_client_warnings, test_tracing, test_describe_mv, test_unicode_invalid_request_error, test_describe

### DIFF
--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -1542,6 +1542,9 @@ CREATE TYPE test.address_type (
 
     def get_users_by_state_mv_output(self):
         if self.cluster.version() >= LooseVersion('4.2'):
+            compaction = self.get_compaction() if self.is_cc5() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
             return """
                 CREATE MATERIALIZED VIEW test.users_by_state AS
                 SELECT *
@@ -1567,7 +1570,7 @@ CREATE TYPE test.address_type (
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p';
-               """ % self.get_compaction() 
+               """ % compaction
         elif self.cluster.version() >= LooseVersion('4.1'):
             return """
                 CREATE MATERIALIZED VIEW test.users_by_state AS
@@ -1594,6 +1597,10 @@ CREATE TYPE test.address_type (
                 AND speculative_retry = '99p';
                """
         elif self.cluster.version() >= LooseVersion('4.0'):
+            compaction = self.get_compaction() if self.is_cc4() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
+            memtable = "AND memtable = {}" if self.is_cc4() else ""
             return """
                 CREATE MATERIALIZED VIEW test.users_by_state AS
                 SELECT *
@@ -1606,9 +1613,9 @@ CREATE TYPE test.address_type (
                 AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
                 AND cdc = false
                 AND comment = ''
-                AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+                %s
                 AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-                AND memtable = {}
+                %s
                 AND crc_check_chance = 1.0
                 AND extensions = {}
                 AND gc_grace_seconds = 864000
@@ -1617,7 +1624,7 @@ CREATE TYPE test.address_type (
                 AND min_index_interval = 128
                 AND read_repair = 'BLOCKING'
                 AND speculative_retry = '99p';
-               """
+               """ % (compaction, memtable)
         elif self.cluster.version() >= LooseVersion('3.9'):
             return """
                 CREATE MATERIALIZED VIEW test.users_by_state AS

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -130,7 +130,7 @@ class TestCqlsh(Tester, CqlshMixin):
         super(TestCqlsh, self).tearDown()
 
 
-    def get_compaction(self):
+    def get_cc_compaction(self):
         # CC uses UCS by default
         cc_ucs = "AND compaction = {'class': 'org.apache.cassandra.db.compaction.UnifiedCompactionStrategy'}"
         if self.dtest_config.latest_config:
@@ -1192,6 +1192,9 @@ CREATE TYPE test.address_type (
                 """
 
         if self.cluster.cassandra_version() >= LooseVersion('5.1'):
+            compaction = self.get_cc_compaction() if self.is_cc5() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
             create_table += """
         ) WITH CLUSTERING ORDER BY (col ASC)
             AND additional_write_policy = '99p'
@@ -1216,8 +1219,11 @@ CREATE TYPE test.address_type (
             AND transactional_mode = 'off'
             AND transactional_migration_from = 'none'
             AND speculative_retry = '99p';
-        """ % self.get_compaction()
+        """ % compaction
         elif self.cluster.version() >= LooseVersion('4.2'):
+            compaction = self.get_cc_compaction() if self.is_cc5() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
             create_table += """
         ) WITH CLUSTERING ORDER BY (col ASC)
             AND additional_write_policy = '99p'
@@ -1239,7 +1245,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p';
-        """ % self.get_compaction()
+        """ % compaction
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table += """
         ) WITH CLUSTERING ORDER BY (col ASC)
@@ -1262,6 +1268,10 @@ CREATE TYPE test.address_type (
             AND speculative_retry = '99p';
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
+            compaction = self.get_cc_compaction() if self.is_cc4() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
+            memtable = "AND memtable = {}" if self.is_cc4() else ""
             create_table += """
         ) WITH CLUSTERING ORDER BY (col ASC)
             AND additional_write_policy = '99p'
@@ -1269,9 +1279,9 @@ CREATE TYPE test.address_type (
             AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
             AND cdc = false
             AND comment = ''
-            AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+            %s
             AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-            AND memtable = {}
+            %s
             AND crc_check_chance = 1.0
             AND default_time_to_live = 0
             AND extensions = {}
@@ -1281,7 +1291,8 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p';
-        """
+        """ % (compaction, memtable)
+
         elif self.cluster.version() >= LooseVersion('3.9'):
             create_table += """
         ) WITH CLUSTERING ORDER BY (col ASC)
@@ -1348,6 +1359,9 @@ CREATE TYPE test.address_type (
         create_table = None
 
         if self.cluster.version() >= LooseVersion('5.1'):
+            compaction = self.get_cc_compaction() if self.is_cc5() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
             create_table = """
         CREATE TABLE test.users (
             userid text PRIMARY KEY,
@@ -1376,8 +1390,11 @@ CREATE TYPE test.address_type (
             AND transactional_mode = 'off'
             AND transactional_migration_from = 'none'
             AND speculative_retry = '99p';
-        """ % self.get_compaction()
+        """ % compaction
         elif self.cluster.version() >= LooseVersion('4.2'):
+            compaction = self.get_cc_compaction() if self.is_cc5() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
             create_table = """
         CREATE TABLE test.users (
             userid text PRIMARY KEY,
@@ -1403,7 +1420,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p';
-        """ % self.get_compaction()
+        """ % compaction
         elif self.cluster.version() >= LooseVersion('4.1'):
             create_table = """
         CREATE TABLE test.users (
@@ -1430,6 +1447,10 @@ CREATE TYPE test.address_type (
             AND speculative_retry = '99p';
         """
         elif self.cluster.version() >= LooseVersion('4.0'):
+            compaction = self.get_cc_compaction() if self.is_cc4() else (
+                "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
+                "'max_threshold': '32', 'min_threshold': '4'}")
+            memtable = "AND memtable = {}" if self.is_cc4() else ""
             create_table = """
         CREATE TABLE test.users (
             userid text PRIMARY KEY,
@@ -1441,9 +1462,9 @@ CREATE TYPE test.address_type (
             AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
             AND cdc = false
             AND comment = ''
-            AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
+            %s
             AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-            AND memtable = {}
+            %s
             AND crc_check_chance = 1.0
             AND default_time_to_live = 0
             AND extensions = {}
@@ -1453,7 +1474,7 @@ CREATE TYPE test.address_type (
             AND min_index_interval = 128
             AND read_repair = 'BLOCKING'
             AND speculative_retry = '99p';
-        """
+        """ % (compaction, memtable)
         elif self.cluster.version() >= LooseVersion('3.9'):
             create_table =  """
         CREATE TABLE test.users (
@@ -1542,7 +1563,7 @@ CREATE TYPE test.address_type (
 
     def get_users_by_state_mv_output(self):
         if self.cluster.version() >= LooseVersion('4.2'):
-            compaction = self.get_compaction() if self.is_cc5() else (
+            compaction = self.get_cc_compaction() if self.is_cc5() else (
                 "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
                 "'max_threshold': '32', 'min_threshold': '4'}")
             return """
@@ -1597,7 +1618,7 @@ CREATE TYPE test.address_type (
                 AND speculative_retry = '99p';
                """
         elif self.cluster.version() >= LooseVersion('4.0'):
-            compaction = self.get_compaction() if self.is_cc4() else (
+            compaction = self.get_cc_compaction() if self.is_cc4() else (
                 "AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', "
                 "'max_threshold': '32', 'min_threshold': '4'}")
             memtable = "AND memtable = {}" if self.is_cc4() else ""

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -2111,7 +2111,7 @@ CREATE TABLE datetime_checks.values (
 
         if self.cluster.version() >= LooseVersion('5.0'):
             # See CASSANDRA-18547
-            self.verify_output("use tracing_checks; tracing on; select * from test", node1, """{}.
+            self.verify_output("use tracing_checks; tracing on; select * from test", node1, """{}
 
  id | val
 ----+-------
@@ -2120,9 +2120,9 @@ CREATE TABLE datetime_checks.values (
   3 | iuiou
 
 (3 rows)
-""".format('Tracing set to FULL' if node1.is_converged_core() else 'Tracing set to ON'))
+""".format('Tracing set to FULL.' if node1.is_converged_core() else 'TRACING set to ON'))
         else:
-            self.verify_output("use tracing_checks; tracing on; select * from test", node1, """Now Tracing is enabled
+            self.verify_output("use tracing_checks; tracing on; select * from test", node1, """{}
 
  id | val
 ----+-------
@@ -2132,7 +2132,7 @@ CREATE TABLE datetime_checks.values (
 
 (3 rows)
 
-Tracing session:""")
+Tracing session:""".format('Tracing set to FULL.' if node1.is_converged_core() else 'Now Tracing is enabled'))
 
     @since('2.2')
     def test_client_warnings(self):

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -2189,9 +2189,17 @@ Tracing session:""")
         logger.debug(fut.warnings)
         assert fut.warnings is not None
         assert 1 == len(fut.warnings)
-        expected_fut_warning = ("Guardrail unlogged_batch_across_partitions violated: Unlogged batch covering {} partitions detected against table [client_warnings.test]. " +
-                                "You should use a logged batch for atomicity, or asynchronous writes for performance.") \
-                                .format(max_partitions_per_batch + 1)
+        if self.is_cc5():
+            expected_fut_warning = (
+                        "Guardrail unlogged_batch_across_partitions violated: Unlogged batch covering {} partitions detected against table [client_warnings.test]. " +
+                        "You should use a logged batch for atomicity, or asynchronous writes for performance.") \
+                .format(max_partitions_per_batch + 1)
+        else:
+            expected_fut_warning = (
+                    "Unlogged batch covering {} partitions detected against table [client_warnings.test]. " +
+                    "You should use a logged batch for atomicity, or asynchronous writes for performance.") \
+                .format(max_partitions_per_batch + 1)
+
         assert expected_fut_warning == fut.warnings[0]
 
     def test_connect_timeout(self):

--- a/cqlsh_tests/test_cqlsh.py
+++ b/cqlsh_tests/test_cqlsh.py
@@ -602,7 +602,7 @@ UPDATE varcharmaptable SET varcharvarintmap['Vitrum edere possum, mihi non nocet
             # See CASSANDRA-15985 for more details
             err = node1.run_cqlsh(cmds=cmd, cqlsh_options=options).stderr
 
-        if self.cluster.version() >= LooseVersion('5.0'):
+        if self.is_cc5() or self.is_cc4():
             assert "Keyspace name must not be empty, more than 222 characters long, or contain non-alphanumeric-underscore characters (got 'ä')" in err
         elif self.cluster.version() >= LooseVersion('4.0'):
             assert "Keyspace name must not be empty, more than 48 characters long, or contain non-alphanumeric-underscore characters (got 'ä')" in err


### PR DESCRIPTION
The tests were run locally against main, main-5.0, Apache cassandra-4.0, cassandra-4.1 and cassandra-5.0 branches and now they all pass.