### PR TITLE
CNDB-16554: Fix post CNDB-11242 and redacting of queries 

### DIFF
--- a/cql_test.py
+++ b/cql_test.py
@@ -1157,6 +1157,11 @@ class TestCQLSlowQuery(CQLTester):
 
     @staticmethod
     def _assert_logs_slow_queries(node, session):
+        # This is the default value for cassandra.cluster_version_provider.min_stable_duration_ms
+        # which gives the time for the cluster to settle and have the correct view for upgrade
+        # state and min versions.
+        # Before this view the ColumnFilter will work in backward compatibility mode and the
+        # test will fail because it always logs SELECT * for all queries. (CNDB-16554)
         time.sleep(60)
         TestCQLSlowQuery._assert_logs_slow_queries_with_skinny_table(node, session)
         for asc in (True, False):

--- a/cql_test.py
+++ b/cql_test.py
@@ -1157,6 +1157,7 @@ class TestCQLSlowQuery(CQLTester):
 
     @staticmethod
     def _assert_logs_slow_queries(node, session):
+        time.sleep(60)
         TestCQLSlowQuery._assert_logs_slow_queries_with_skinny_table(node, session)
         for asc in (True, False):
             TestCQLSlowQuery._assert_logs_slow_queries_with_wide_table(node, session, asc=asc)
@@ -1540,7 +1541,7 @@ class TestCQLSlowQuery(CQLTester):
                                         consistency_level=ConsistencyLevel.ONE,
                                         retry_policy=FallthroughRetryPolicy()))
 
-        if node.is_converged_core() and node.cluster.version() >= '5.0':
+        if node.is_converged_core() and node.cluster.version() >= '4.0':
             logged_query = TestCQLSlowQuery._redact_logged_query(logged_query)
 
         node.watch_log_for(["operations were slow", logged_query.format(table)],


### PR DESCRIPTION
CNDB-16554: Fix post CNDB-11242 (while min node in a cluster is NULL_VERSION the cluster is viewed as being in upgrade state) and redacting of queries.

The sleep added is to account until Gossip is aware that we have a cluster not in upgrade and we do not have to trigger backward compatibility paths. If we were to think there is upgrade from nodes under version 3.4, according to the `ColumnFilter` we were fetching all columns and not only selected columns with point queries.

We will look into fix for the fake upgrade issue on startup in another ticket - CNDB-13394.