### PR TITLE
CNDB-16864: Add source/target version filters for upgrade test matrix

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -99,6 +99,10 @@ def pytest_addoption(parser):
                      help="Enable JaCoCo Code Coverage Support")
     parser.addoption("--upgrade-version-selection", action="store", default="indev",
                      help="Specify whether to run indev, releases, or both")
+    parser.addoption("--upgrade-source-filter", action="store", default="",
+                     help="Comma-separated list of source version names (e.g., 'indev_cc4,current_hcd_1'). Narrows results from --upgrade-version-selection")
+    parser.addoption("--upgrade-target-filter", action="store", default="",
+                     help="Comma-separated list of target version names (e.g., 'indev_cc5'). Narrows results from --upgrade-version-selection")
     parser.addoption("--upgrade-target-version-only", action="store_true", default=False,
                      help="When running upgrade tests, only run tests upgrading to the current version")
     parser.addoption("--metatests", action="store_true", default=False,

--- a/conftest.py
+++ b/conftest.py
@@ -100,9 +100,9 @@ def pytest_addoption(parser):
     parser.addoption("--upgrade-version-selection", action="store", default="indev",
                      help="Specify whether to run indev, releases, or both")
     parser.addoption("--upgrade-source-filter", action="store", default="",
-                     help="Comma-separated list of source version names (e.g., 'indev_cc4,current_hcd_1'). Narrows results from --upgrade-version-selection")
+                     help="Comma-separated list of source version names (e.g., 'indev_3_0_x,indev_4_0_x'). Narrows results from --upgrade-version-selection")
     parser.addoption("--upgrade-target-filter", action="store", default="",
-                     help="Comma-separated list of target version names (e.g., 'indev_cc5'). Narrows results from --upgrade-version-selection")
+                     help="Comma-separated list of target version names (e.g., 'indev_5_0_x'). Narrows results from --upgrade-version-selection")
     parser.addoption("--upgrade-target-version-only", action="store_true", default=False,
                      help="When running upgrade tests, only run tests upgrading to the current version")
     parser.addoption("--metatests", action="store_true", default=False,

--- a/dtest_setup.py
+++ b/dtest_setup.py
@@ -532,6 +532,10 @@ class DTestSetup(object):
                 self.cluster._config_options.pop('repaired_data_tracking_for_range_reads_enabled', None)
                 self.cluster._config_options.pop('report_unconfirmed_repaired_data_mismatches', None)
                 self.cluster._config_options.pop('corrupted_tombstone_strategy', None)
+        # storage_compatibility_mode is only supported in 5.0+
+        if self.cluster.cassandra_version() < LooseVersion('5.0'):
+            if self.cluster._config_options is not None:
+                self.cluster._config_options.pop('storage_compatibility_mode', None)
 
     def maybe_setup_jacoco(self, cluster_name='test'):
         """Setup JaCoCo code coverage support"""

--- a/upgrade_tests/upgrade_manifest.py
+++ b/upgrade_tests/upgrade_manifest.py
@@ -340,8 +340,34 @@ def build_upgrade_pairs():
     valid_upgrade_pairs = []
     manifest = MANIFEST
 
+    # Get configuration options
+    source_filter_str = CONFIG.getoption("--upgrade-source-filter")
+    target_filter_str = CONFIG.getoption("--upgrade-target-filter")
     configured_strategy = CONFIG.getoption("--upgrade-version-selection").upper()
+
+    # Step 1: Apply version selection strategy to get initial set of upgrade paths
     version_select_strategy = VersionSelectionStrategies[configured_strategy].value[0]
+    logger.info(f"Using version selection strategy: {configured_strategy}")
+
+    # Step 2: Apply source/target filters to narrow down the results (if specified)
+    if source_filter_str or target_filter_str:
+        # Parse comma-separated version names
+        allowed_source_names = set(name.strip() for name in source_filter_str.split(',') if name.strip()) if source_filter_str else None
+        allowed_target_names = set(name.strip() for name in target_filter_str.split(',') if name.strip()) if target_filter_str else None
+
+        if allowed_source_names:
+            logger.info(f"Applying source version filter: {allowed_source_names}")
+            # Filter manifest based on source filter
+            manifest = {k: v for k, v in MANIFEST.items() if k.name in allowed_source_names}
+
+        if allowed_target_names:
+            logger.info(f"Applying target version filter: {allowed_target_names}")
+            # Filter destination versions based on target filter
+            manifest = {k: [v for v in vs if v.name in allowed_target_names] for k, vs in manifest.items()}
+
+        # Remove entries with no valid destinations
+        manifest = {k: v for k, v in manifest.items() if v}
+
     filter_for_current_family = CONFIG.getoption("--upgrade-target-version-only")
 
     for origin_meta, destination_metas in list(manifest.items()):

--- a/upgrade_tests/upgrade_through_versions_test.py
+++ b/upgrade_tests/upgrade_through_versions_test.py
@@ -89,7 +89,7 @@ def data_writer(tester, to_verify_queue, verification_done_queue, rewrite_probab
                 time.sleep(1)  # Pstmnt id mismatch, retry. See CASSANDRA-15252/17140
                 continue
             else:
-                logger.error("Error in data writer process!", dex)
+                logger.error("Error in data writer process!", exc_info=True)
                 shutdown_gently()
                 raise
         except OperationTimedOut:
@@ -100,7 +100,7 @@ def data_writer(tester, to_verify_queue, verification_done_queue, rewrite_probab
             time.sleep(1)
             continue
         except Exception as ex:
-            logger.error("Error in data writer process!", exc_info=ex)
+            logger.error("Error in data writer process!", exc_info=True)
             shutdown_gently()
             raise
 
@@ -144,7 +144,7 @@ def data_checker(tester, to_verify_queue, verification_done_queue):
             # we would end up blocking indefinitely
             (key, expected_val) = to_verify_queue.get_nowait()
 
-            actual_val = session.execute(prepared, (key,))[0][0]
+            actual_val = session.execute(prepared, (key,), timeout=30)[0][0]
         except Empty:
             time.sleep(1)  # let's not eat CPU if the queue is empty
             logger.info("to_verify_queue is empty: %d" % to_verify_queue.qsize())
@@ -154,7 +154,7 @@ def data_checker(tester, to_verify_queue, verification_done_queue):
                 time.sleep(1)  # Pstmnt id mismatch, retry. See CASSANDRA-15252/17140
                 continue
             else:
-                logger.error("Error in data checker process!", dex)
+                logger.error("Error in data checker process!", exc_info=True)
                 shutdown_gently()
                 raise
         except OperationTimedOut:
@@ -165,7 +165,7 @@ def data_checker(tester, to_verify_queue, verification_done_queue):
             time.sleep(1)
             continue
         except Exception as ex:
-            logger.error("Error in data checker process!", ex)
+            logger.error("Error in data checker process!", exc_info=True)
             shutdown_gently()
             raise
         else:
@@ -178,7 +178,7 @@ def data_checker(tester, to_verify_queue, verification_done_queue):
                 # rewrite rows in the same sequence as originally written
                 pass
             except Exception as ex:
-                logger.error("Failed to put into verification_done_queue", ex)
+                logger.error("Failed to put into verification_done_queue", exc_info=True)
 
         assert expected_val == actual_val, "Data did not match expected value!"
 
@@ -238,7 +238,7 @@ def counter_incrementer(tester, to_verify_queue, verification_done_queue, rewrit
                 time.sleep(1)  # Pstmnt id mismatch, retry. See CASSANDRA-15252/17140
                 continue
             else:
-                logger.error("Error in counter incrementer process!", dex)
+                logger.error("Error in counter incrementer process!", exc_info=True)
                 shutdown_gently()
                 raise
         except OperationTimedOut:
@@ -249,7 +249,7 @@ def counter_incrementer(tester, to_verify_queue, verification_done_queue, rewrit
             time.sleep(1)
             continue
         except Exception as ex:
-            logger.error("Error in counter incrementer process!", ex)
+            logger.error("Error in counter incrementer process!", exc_info=True)
             shutdown_gently()
             raise
 
@@ -302,7 +302,7 @@ def counter_checker(tester, to_verify_queue, verification_done_queue):
                 time.sleep(1)  # Pstmnt id mismatch, retry. See CASSANDRA-15252/17140
                 continue
             else:
-                logger.error("Error in counter verifier process!", dex)
+                logger.error("Error in counter verifier process!", exc_info=True)
                 shutdown_gently()
                 raise
         except OperationTimedOut:
@@ -313,7 +313,7 @@ def counter_checker(tester, to_verify_queue, verification_done_queue):
             time.sleep(1)
             continue
         except Exception as ex:
-            logger.error("Error in counter verifier process!", ex)
+            logger.error("Error in counter verifier process!", exc_info=True)
             shutdown_gently()
             raise
         else:


### PR DESCRIPTION
## Summary
Adds composable filtering options to narrow the upgrade test matrix scope while preserving existing `VersionSelectionStrategy` behavior. This enables targeted testing of specific upgrade paths without running the full matrix.

## Changes

### 1. Add CLI filter options (`conftest.py`)
- `--upgrade-source-filter`: Comma-separated list of source version names to test
- `--upgrade-target-filter`: Comma-separated list of target version names to test
- Filters narrow results **after** applying `--upgrade-version-selection` strategy

### 2. Implement two-step filtering (`upgrade_tests/upgrade_manifest.py`)
The `build_upgrade_pairs()` function now:
1. Applies `VersionSelectionStrategy` based on `--upgrade-version-selection` (e.g., `INDEV`, `BOTH`, `ALL`)
2. Filters source versions (if `--upgrade-source-filter` specified)
3. Filters target versions (if `--upgrade-target-filter` specified)
4. Removes entries with no valid destinations after filtering
5. Logs the applied strategy and filters for debugging

### 3. Fix logger.error format bugs (`upgrade_tests/upgrade_through_versions_test.py`)
- Fixed `logger.error()` calls to use `exc_info=True` instead of passing exception as positional argument
- Added `timeout=30` parameter to `session.execute()` in `data_checker()` to prevent indefinite hangs
- **Impact**: Previously, incorrect `logger.error()` usage could cause `TypeError`, preventing the `raise` statement from executing and leaving subprocesses running in a broken state

## Example Usage

Test all indev→indev upgrade paths (existing behavior):
```bash
pytest upgrade_tests/ \
  --upgrade-version-selection=indev
```

Test only indev sources upgrading to trunk:
```bash
pytest upgrade_tests/ \
  --upgrade-version-selection=indev \
  --upgrade-target-filter=indev_trunk
```

Test specific source upgrading to specific target:
```bash
pytest upgrade_tests/ \
  --upgrade-source-filter=indev_4_0_x \
  --upgrade-target-filter=indev_4_1_x
```

Test all INDEV strategy paths but only from 4.1.x sources:
```bash
pytest upgrade_tests/ \
  --upgrade-version-selection=indev \
  --upgrade-source-filter=indev_4_1_x
```
