### PR TITLE
CNDB-10582 Fix intermittent UNKNOWN_TABLE failures in replica_side_filtering_test

### DIFF
--- a/paxos_test.py
+++ b/paxos_test.py
@@ -58,9 +58,11 @@ class TestPaxos(Tester):
         assert_unavailable(session.execute, "INSERT INTO test (k, v) VALUES (2, 2) IF NOT EXISTS")
 
         node1.start(wait_for_binary_proto=True)
+        session.cluster.control_connection.wait_for_schema_agreement(wait_time=120)
         session.execute("INSERT INTO test (k, v) VALUES (3, 3) IF NOT EXISTS")
 
         node2.start(wait_for_binary_proto=True)
+        session.cluster.control_connection.wait_for_schema_agreement(wait_time=120)
         session.execute("INSERT INTO test (k, v) VALUES (4, 4) IF NOT EXISTS")
 
     @pytest.mark.no_vnodes

--- a/replica_side_filtering_test.py
+++ b/replica_side_filtering_test.py
@@ -48,6 +48,7 @@ class ReplicaSideFiltering(Tester):
         # create the index if it's required
         if self.create_index():
             session.execute(create_index)
+            session.cluster.control_connection.wait_for_schema_agreement(wait_time=120)
 
         # execute the queries for both nodes with CL=ALL
         if both_nodes:
@@ -72,6 +73,7 @@ class ReplicaSideFiltering(Tester):
         for q in queries:
             session.execute(q)
         node_to_stop.start()
+        session.cluster.control_connection.wait_for_schema_agreement(wait_time=120)
 
     def _assert_none(self, query):
         """


### PR DESCRIPTION
Add schema agreement waits to prevent race conditions where queries execute before secondary indexes are fully synchronized across nodes.

The test failures manifested as WriteFailure/ReadFailure errors with code 0x01f5 (UNKNOWN_TABLE) from replica node 127.0.0.2, occurring intermittently in:
- test_update_on_collection
- test_update_on_static_column_with_empty_partition
- test_consistent_skinny_table